### PR TITLE
Add new performence table : count nb_units above threshold

### DIFF
--- a/spiketoolkit/comparison/sortingcomparison.py
+++ b/spiketoolkit/comparison/sortingcomparison.py
@@ -353,6 +353,13 @@ class SortingComparison():
             perf = self.get_performance(method=method, output='dict')
             txt = _template_txt_performance.format(method=method, **perf)
             print(txt)
+    
+    def get_number_units_above_threshold(self, columns='accuracy', threshold=95, ):
+        perf = self.get_performance(method='by_spiketrain', output='pandas')
+        nb = (perf[columns] > threshold).sum()
+        return nb
+        
+        
 
 
 class MappedSortingExtractor(se.SortingExtractor):


### PR DESCRIPTION
This count how many units above threshold (95% by default) have been detected.
This is done on ['tp_rate', 'accuracy', 'sensitivity'].

Spikeforest have a similar metric but not implemented in spiketoolkit.
It is important to have it.
