### PR TITLE
fixes to posptocessing, kilosort, and multicomp

### DIFF
--- a/spiketoolkit/comparison/comparisontools.py
+++ b/spiketoolkit/comparison/comparisontools.py
@@ -475,8 +475,9 @@ def compare_spike_trains(spiketrain1, spiketrain2, delta_frames=10):
     for sp_i, n_sp in enumerate(spiketrain1):
         matches = (np.abs(spiketrain2.astype(int) - n_sp) <= delta_frames // 2)
         if np.sum(matches) > 0:
-            lab_st1[sp_i] = 'TP'
-            lab_st2[np.where(matches)[0][0]] = 'TP'
+            if lab_st1[sp_i] != 'TP' and lab_st2[np.where(matches)[0][0]] != 'TP':
+                lab_st1[sp_i] = 'TP'
+                lab_st2[np.where(matches)[0][0]] = 'TP'
 
     for l_gt, lab in enumerate(lab_st1):
         if lab == 'UNPAIRED':

--- a/spiketoolkit/comparison/comparisontools.py
+++ b/spiketoolkit/comparison/comparisontools.py
@@ -261,8 +261,9 @@ def do_score_labels(sorting1, sorting2, delta_frames, unit_map12):
             for sp_i, n_sp in enumerate(sts1[u1]):
                 matches = (np.abs(mapped_st.astype(int)-n_sp)<=delta_frames//2)
                 if np.sum(matches) > 0:
-                    lab_st1[sp_i] = 'TP'
-                    lab_st2[np.where(matches)[0][0]] = 'TP'
+                    if lab_st1[sp_i] != 'TP' and lab_st2[np.where(matches)[0][0]] != 'TP':
+                        lab_st1[sp_i] = 'TP'
+                        lab_st2[np.where(matches)[0][0]] = 'TP'
         else:
             lab_st1 = np.array(['FN'] * len(sts1[u1]))
             labels_st1[u1] = lab_st1
@@ -280,8 +281,9 @@ def do_score_labels(sorting1, sorting2, delta_frames, unit_map12):
                         mapped_st = sts2[u2]
                         matches = (np.abs(mapped_st.astype(int)-n_sp)<=delta_frames//2)
                         if np.sum(matches) > 0:
-                            lab_st1[l_gt] = 'CL_' + str(u1) + '_' + str(u2)
-                            lab_st2[np.where(matches)[0][0]] = 'CL_' + str(u2) + '_' + str(u1)
+                            if 'CL' not in lab_st1[l_gt] and 'CL' not in lab_st2[np.where(matches)[0][0]]:
+                                lab_st1[l_gt] = 'CL_' + str(u1) + '_' + str(u2)
+                                lab_st2[np.where(matches)[0][0]] = 'CL_' + str(u2) + '_' + str(u1)
 
 
     for u1 in unit1_ids:

--- a/spiketoolkit/comparison/multisortingcomparison.py
+++ b/spiketoolkit/comparison/multisortingcomparison.py
@@ -191,7 +191,7 @@ class MultiSortingComparison():
         sorted_name_list = sorted(self._name_list)
         sorting_agr = AgreementSortingExtractor(self, minimum_matching)
         unit_ids = sorting_agr.get_unit_ids()
-        agreement_matrix = _do_agreement_matrix(minimum_matching)
+        agreement_matrix = self._do_agreement_matrix(minimum_matching)
 
         fig, ax = plt.subplots()
         # Using matshow here just because it sets the ticks up nicely. imshow is faster.

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -366,9 +366,9 @@ def get_unit_max_channel(recording, sorting, unit_ids=None, grouping_property=No
                                        ms_before=ms_before, ms_after=ms_after,  grouping_property=grouping_property,
                                        compute_property_from_recording=compute_property_from_recording,
                                        verbose=verbose)
-        max_chan = np.unravel_index(np.argmax(np.abs(template)),
+        max_channel_idx = np.unravel_index(np.argmax(np.abs(template)),
                                     template.shape)[0]
-        max_channel = recording.get_channel_ids()[max_chan]
+        max_channel = recording.get_channel_ids()[max_channel_idx]
         if save_as_property:
             sorting.set_unit_property(unit_id, 'max_channel', max_channel)
 
@@ -383,7 +383,7 @@ def get_unit_max_channel(recording, sorting, unit_ids=None, grouping_property=No
 def compute_pca_scores(recording, sorting, unit_ids=None, n_comp=3, by_electrode=False, grouping_property=None,
                        start_frame=None, end_frame=None, ms_before=3., ms_after=3., dtype=None,
                        max_num_waveforms=np.inf, save_as_features=True, compute_property_from_recording=False,
-                       verbose=False):
+                       whiten=True, verbose=False):
     '''
     Computes the PCA scores from the unit waveforms. If waveforms are not found as features, they are computed.
 
@@ -419,6 +419,8 @@ def compute_pca_scores(recording, sorting, unit_ids=None, n_comp=3, by_electrode
     compute_property_from_recording: bool
         If True and 'grouping_property' is given, the property of each unit is assigned as the corresponding propery of
         the recording extractor channel on which the average waveform is the largest
+    whiten: bool
+        If True, PCA is run with whiten equal True
     verbose: bool
         If True output is verbose
 
@@ -466,7 +468,7 @@ def compute_pca_scores(recording, sorting, unit_ids=None, n_comp=3, by_electrode
             wf = get_unit_waveforms(recording, sorting, unit_id, start_frame=start_frame,
                                     end_frame=end_frame, max_num_waveforms=max_num_waveforms,
                                     ms_before=ms_before, ms_after=ms_after,
-                                    grouping_property=grouping_property,
+                                    grouping_property=grouping_property, dtype=dtype,
                                     compute_property_from_recording=compute_property_from_recording,
                                     verbose=verbose)
         if by_electrode:
@@ -482,7 +484,7 @@ def compute_pca_scores(recording, sorting, unit_ids=None, n_comp=3, by_electrode
     if verbose:
         print("Fitting PCA of %d dimensions on %d waveforms" % (n_comp, len(all_waveforms)))
 
-    pca = PCA(n_components=n_comp, whiten=False)
+    pca = PCA(n_components=n_comp, whiten=whiten)
     pca.fit(all_waveforms)
 
     pca_scores = []

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -491,6 +491,8 @@ def compute_pca_scores(recording, sorting, unit_ids=None, n_comp=3, by_electrode
     # project waveforms on principal components
     for wf in waveforms:
         pct = np.dot(wf, pca.components_.T)
+        if whiten:
+            pct /= np.sqrt(pca.explained_variance_)
         pca_scores.append(pct)
 
     if save_as_features:

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -383,7 +383,7 @@ def get_unit_max_channel(recording, sorting, unit_ids=None, grouping_property=No
 def compute_pca_scores(recording, sorting, unit_ids=None, n_comp=3, by_electrode=False, grouping_property=None,
                        start_frame=None, end_frame=None, ms_before=3., ms_after=3., dtype=None,
                        max_num_waveforms=np.inf, save_as_features=True, compute_property_from_recording=False,
-                       whiten=True, verbose=False):
+                       whiten=False, verbose=False):
     '''
     Computes the PCA scores from the unit waveforms. If waveforms are not found as features, they are computed.
 

--- a/spiketoolkit/preprocessing/remove_bad_channels.py
+++ b/spiketoolkit/preprocessing/remove_bad_channels.py
@@ -24,7 +24,6 @@ class RemoveBadChannelsRecording(RecordingExtractor):
         self._initialize_subrecording_extractor()
         self.copy_channel_properties(recording=self._subrecording)
 
-
     def get_sampling_frequency(self):
         return self._subrecording.get_sampling_frequency()
 
@@ -57,6 +56,7 @@ class RemoveBadChannelsRecording(RecordingExtractor):
             traces = self._recording.get_traces(start_frame=start_frame, end_frame=end_frame)
             stds = np.std(traces, axis=1)
             bad_channels = [ch for ch, std in enumerate(stds) if std > self._bad_threshold * np.median(stds)]
+            print('Automatically removing channels:', bad_channels)
             active_channels = []
             for chan in self._recording.get_channel_ids():
                 if chan not in bad_channels:
@@ -64,7 +64,7 @@ class RemoveBadChannelsRecording(RecordingExtractor):
             self._subrecording = SubRecordingExtractor(self._recording, channel_ids=active_channels)
         else:
             self._subrecording = self._recording
-
+        self.active_channels = active_channels
 
 def remove_bad_channels(recording, bad_channels, bad_threshold=2, seconds=10):
     '''

--- a/spiketoolkit/sorters/kilosort/kilosort.py
+++ b/spiketoolkit/sorters/kilosort/kilosort.py
@@ -175,7 +175,7 @@ class KilosortSorter(BaseSorter):
                                                    groups,
                                                    recording.get_sampling_frequency())
         else:
-            raise Exception("Electrode dimension should bi a list of len 2")
+            raise Exception("Electrode dimension should be a list of len 2")
 
         for fname, value in zip(['kilosort_master.m', 'kilosort_config.m',
                                  'kilosort_channelmap.m'],

--- a/spiketoolkit/sorters/kilosort/kilosort.py
+++ b/spiketoolkit/sorters/kilosort/kilosort.py
@@ -155,26 +155,27 @@ class KilosortSorter(BaseSorter):
             groups = [recording.get_channel_property(ch, 'group') for ch in recording.get_channel_ids()]
         else:
             groups = 'ones(1, Nchannels)'
-        if 'location' in recording.get_channel_property_names():
-            positions = np.array([recording.get_channel_property(chan, 'location') for chan in recording.get_channel_ids()])
-            if electrode_dimensions is None:
-                kilosort_channelmap = ''.join(kilosort_channelmap
-                                              ).format(nchan,
-                                                       list(positions[:, 0]),
-                                                       list(positions[:, 1]),
-                                                       groups,
-                                                       sample_rate)
-            elif len(electrode_dimensions) == 2:
-                kilosort_channelmap = ''.join(kilosort_channelmap
-                                              ).format(nchan,
-                                                       list(positions[:, electrode_dimensions[0]]),
-                                                       list(positions[:, electrode_dimensions[1]]),
-                                                       groups,
-                                                       recording.get_sampling_frequency())
-            else:
-                raise Exception("Electrode dimension should bi a list of len 2")
+        if 'location' not in recording.get_channel_property_names():
+            print("'location' information is not found. Using linear configuration")
+            for i_ch, ch in enumerate(recording.get_channel_ids()):
+                recording.set_channel_property(ch, 'location', [0, i_ch])
+        positions = np.array([recording.get_channel_property(chan, 'location') for chan in recording.get_channel_ids()])
+        if electrode_dimensions is None:
+            kilosort_channelmap = ''.join(kilosort_channelmap
+                                          ).format(nchan,
+                                                   list(positions[:, 0]),
+                                                   list(positions[:, 1]),
+                                                   groups,
+                                                   sample_rate)
+        elif len(electrode_dimensions) == 2:
+            kilosort_channelmap = ''.join(kilosort_channelmap
+                                          ).format(nchan,
+                                                   list(positions[:, electrode_dimensions[0]]),
+                                                   list(positions[:, electrode_dimensions[1]]),
+                                                   groups,
+                                                   recording.get_sampling_frequency())
         else:
-            raise Exception("'location' information is needed. Provide a probe information with a 'probe_file'")
+            raise Exception("Electrode dimension should bi a list of len 2")
 
         for fname, value in zip(['kilosort_master.m', 'kilosort_config.m',
                                  'kilosort_channelmap.m'],

--- a/spiketoolkit/sorters/kilosort2/kilosort2.py
+++ b/spiketoolkit/sorters/kilosort2/kilosort2.py
@@ -171,8 +171,7 @@ class Kilosort2Sorter(BaseSorter):
                                                    groups,
                                                    recording.get_sampling_frequency())
         else:
-            raise Exception("Electrode dimension should bi a list of len 2")
-
+            raise Exception("Electrode dimension should be a list of len 2")
 
         for fname, value in zip(['kilosort2_master.m', 'kilosort2_config.m',
                                  'kilosort2_channelmap.m'],

--- a/spiketoolkit/sorters/kilosort2/kilosort2.py
+++ b/spiketoolkit/sorters/kilosort2/kilosort2.py
@@ -151,26 +151,28 @@ class Kilosort2Sorter(BaseSorter):
             groups = [recording.get_channel_property(ch, 'group') for ch in recording.get_channel_ids()]
         else:
             groups = 'ones(1, Nchannels)'
-        if 'location' in recording.get_channel_property_names():
-            positions = np.array([recording.get_channel_property(chan, 'location') for chan in recording.get_channel_ids()])
-            if electrode_dimensions is None:
-                kilosort2_channelmap = ''.join(kilosort2_channelmap
-                                              ).format(nchan,
-                                                       list(positions[:, 0]),
-                                                       list(positions[:, 1]),
-                                                       groups,
-                                                       sample_rate)
-            elif len(electrode_dimensions) == 2:
-                kilosort2_channelmap = ''.join(kilosort2_channelmap
-                                              ).format(nchan,
-                                                       list(positions[:, electrode_dimensions[0]]),
-                                                       list(positions[:, electrode_dimensions[1]]),
-                                                       groups,
-                                                       recording.get_sampling_frequency())
-            else:
-                raise Exception("Electrode dimension should bi a list of len 2")
+        if 'location' not in recording.get_channel_property_names():
+            print("'location' information is not found. Using linear configuration")
+            for i_ch, ch in enumerate(recording.get_channel_ids()):
+                recording.set_channel_property(ch, 'location', [0, i_ch])
+        positions = np.array([recording.get_channel_property(chan, 'location') for chan in recording.get_channel_ids()])
+        if electrode_dimensions is None:
+            kilosort2_channelmap = ''.join(kilosort2_channelmap
+                                          ).format(nchan,
+                                                   list(positions[:, 0]),
+                                                   list(positions[:, 1]),
+                                                   groups,
+                                                   sample_rate)
+        elif len(electrode_dimensions) == 2:
+            kilosort2_channelmap = ''.join(kilosort2_channelmap
+                                          ).format(nchan,
+                                                   list(positions[:, electrode_dimensions[0]]),
+                                                   list(positions[:, electrode_dimensions[1]]),
+                                                   groups,
+                                                   recording.get_sampling_frequency())
         else:
-            raise Exception("'location' information is needed. Provide a probe information with a 'probe_file'")
+            raise Exception("Electrode dimension should bi a list of len 2")
+
 
         for fname, value in zip(['kilosort2_master.m', 'kilosort2_config.m',
                                  'kilosort2_channelmap.m'],


### PR DESCRIPTION
- updated export to phy function with improved pca extraction and group settings (working with latest `gloo` phy branch)

-  fixed channel mismatch in get_unit_max_channel

- for kilosort and kilosort2: if location is not given, linear location is assumed

- in multisorting comparison: `compare_spiketrains` checks that spikes have not be labeled as TP before