### PR TITLE
Force tridesclous=1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - pip install Cython
   - pip install h5py # for klusta
   - pip install click klusta klustakwik2
-  - pip install https://github.com/tridesclous/tridesclous/archive/master.zip
+  - pip install tridesclous==1.1.0
   - pip install https://github.com/mhhennig/HS2/archive/master.zip
   - pip install spyking-circus
   - pip install pyqt5

--- a/spiketoolkit/__init__.py
+++ b/spiketoolkit/__init__.py
@@ -1,6 +1,6 @@
 from . import postprocessing
-from . import sorters
 from . import preprocessing
+from . import sorters
 from . import comparison
 from . import validation
 

--- a/spiketoolkit/sorters/mountainsort4/mountainsort4.py
+++ b/spiketoolkit/sorters/mountainsort4/mountainsort4.py
@@ -6,8 +6,9 @@ I need help here because:
 Reading the code do not make evident if there is a persistency on disk.
 
 """
-import spiketoolkit as st
+
 from spiketoolkit.sorters.basesorter import BaseSorter
+from spiketoolkit.preprocessing import bandpass_filter, whiten
 import spikeextractors as se
 import copy
 
@@ -83,12 +84,12 @@ class Mountainsort4Sorter(BaseSorter):
 
         # Bandpass filter
         if p['filter'] and p['freq_min'] is not None and p['freq_max'] is not None:
-            recording = st.preprocessing.bandpass_filter(recording=recording, freq_min=p['freq_min'],
+            recording = bandpass_filter(recording=recording, freq_min=p['freq_min'],
                                                          freq_max=p['freq_max'])
 
         # Whiten
         if p['whiten']:
-            recording = st.preprocessing.whiten(recording=recording)
+            recording = whiten(recording=recording)
 
         # Check location
         if 'location' not in recording.get_channel_property_names():


### PR DESCRIPTION
I have released tridesclous to 1.1.0.
So I force travis.
We should also do the same for HS2 and mountainsort.