### PR TITLE
Tridesclous

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install numpy scipy h5py six cython tqdm click # for klusta
   - pip install klusta
   - pip install klustakwik2==0.2.6
-  - pip install tridesclous==1.1.0
+  - pip install tridesclous==1.2.0
   - pip install herdingspikes==0.3.2
   - pip install spyking-circus
   - pip install pyqt5

--- a/spiketoolkit/sorters/tridesclous/tridesclous.py
+++ b/spiketoolkit/sorters/tridesclous/tridesclous.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     HAVE_TDC = False
 
+print('HAVE_TDC', HAVE_TDC)
 
 class TridesclousSorter(BaseSorter):
     """
@@ -101,7 +102,7 @@ class TridesclousSorter(BaseSorter):
         if nb_chan >64: # this limit depend on the platform of course
             if tdc.cltools.HAVE_PYOPENCL:
                 # force opencl
-                nested_params['fullchain_kargs']['preprocessor']['signalpreprocessor_engine'] = 'opencl'
+                nested_params['preprocessor']['signalpreprocessor_engine'] = 'opencl'
                 use_sparse_template = True
                 use_opencl_with_sparse = True
             else:


### PR DESCRIPTION
I am working on parameters for tridesclous sorter.
DO NOT MERGE NOW because this is depend on tridesclous==1.2.0 that will be release this week.

The main change is parameters name to make less ambiguous units (second vs sample vs ms).

After this could it be possible to make a release of spiketoolkit soon, so I could be able to propagate changes in spikeforest wrapper.
