### PR TITLE
Same changes as in SpikeForest

### DIFF
--- a/spiketoolkit/sorters/spyking_circus/config_default.params
+++ b/spiketoolkit/sorters/spyking_circus/config_default.params
@@ -38,8 +38,7 @@ make_plots     =            # Generate sanity plots of the averaged artefacts [N
 
 [whitening]
 chunk_size     = 30         # Size of the data chunks [in s]
-safety_time    = auto          # Temporal zone around which templates are isolated [in ms, or auto]
-temporal       = False      # Perform temporal whitening
+safety_time    = auto       # Temporal zone around which templates are isolated [in ms, or auto]
 spatial        = True       # Perform spatial whitening
 max_elts       = {}         # Max number of events per electrode (should be compatible with nb_elts)
 nb_elts        = 0.8        # Fraction of max_elts that should be obtained per electrode [0-1]
@@ -51,13 +50,13 @@ safety_space   = True       # If True, we exclude spikes in the vicinity of a se
 safety_time    = auto       # Temporal zone around which templates are isolated [in ms, or auto]
 max_elts       = {}         # Max number of events per electrode (should be compatible with nb_elts)
 nb_elts        = 0.8        # Fraction of max_elts that should be obtained per electrode [0-1]
-nclus_min      = 0.002      # Min number of elements in a cluster (given in percentage) [0-1]
+nclus_min      = 0.005      # Min number of elements in a cluster (given in percentage) [0-1]
 max_clusters   = 10         # Maximal number of clusters for every electrodes WAS 10
 nb_repeats     = 3          # Number of passes used for the clustering
 smart_search   = True       # Activate the smart search mode
-smart_select   = False      # Experimental: activate the smart selection of centroids (max_clusters is ignored)
 sim_same_elec  = 3          # Distance within clusters under which they are re-merged
-cc_merge       = 0.975      # If CC between two templates is higher, they are merged
+sensitivity    = 3          # Single parameter for clustering sensitivity. The lower the more sensitive
+cc_merge       = 0.96       # If CC between two templates is higher, they are merged
 dispersion     = (5, 5)     # Min and Max dispersion allowed for amplitudes [in MAD]
 noise_thr      = 0.8        # Minimal amplitudes are such than amp*min(templates) < noise_thr*threshold in [0-1]
 remove_mixture = True       # At the end of the clustering, we remove mixtures of templates
@@ -65,7 +64,6 @@ make_plots     =            # Generate sanity plots of the clustering [Nothing o
 
 [fitting]
 chunk_size     = 1          # Size of chunks used during fitting [in second] WAS 1
-gpu_only       = False      # Use GPU for computation of b's AND fitting [not optimized yet]
 amp_limits     = (0.3, 5)   # Amplitudes for the templates during spike detection [if not auto] (0.3, 5)
 amp_auto       = True       # True if amplitudes are adjusted automatically for every templates
 max_chunk      = inf        # Fit only up to max_chunk

--- a/spiketoolkit/sorters/spyking_circus/spyking_circus.py
+++ b/spiketoolkit/sorters/spyking_circus/spyking_circus.py
@@ -25,7 +25,7 @@ class SpykingcircusSorter(BaseSorter):
     _default_params = {
         'probe_file': None,
         'detect_sign': -1,  # -1 - 1 - 0
-        'adjacency_radius': 100,  # Channel neighborhood adjacency radius corresponding to geom file
+        'adjacency_radius': 200,  # Channel neighborhood adjacency radius corresponding to geom file
         'detect_threshold': 6,  # Threshold for detection
         'template_width_ms': 3,  # Spyking circus parameter
         'filter': True,
@@ -76,7 +76,7 @@ class SpykingcircusSorter(BaseSorter):
         with (source_dir / 'config_default.params').open('r') as f:
             circus_config = f.readlines()
         if p['merge_spikes']:
-            auto = 1e-5
+            auto = 1
         else:
             auto = 0
         circus_config = ''.join(circus_config).format(sample_rate, p['probe_file'], p['template_width_ms'],


### PR DESCRIPTION
I copied the changes submitted to SpikeForest, in order for the two repos to be in sync. Note that current version of SC is now 0.8.0, available with pip/conda/docker. These changes are not meant to turn the code into a pure automatic software. They are just slightly decreasing the number of clusters, and further investigation should be performed to turn it into a pure automatic workflow.