### PR TITLE
Changed common reference to accept only list for reference channels

### DIFF
--- a/spiketoolkit/preprocessing/common_reference.py
+++ b/spiketoolkit/preprocessing/common_reference.py
@@ -8,12 +8,13 @@ class CommonReferenceRecording(RecordingExtractor):
     _gui_params = [
         {'name': 'reference', 'type': 'str', 'value':'median', 'default':'median', 'title': "Reference type ('median', 'average', or 'single')"},
         {'name': 'groups', 'type': 'int_list', 'value':None, 'default':None, 'title': "List of lists containins the channels for splitting the reference"},
-        {'name': 'ref_channel', 'type': 'int/int_list', 'value':None, 'default':None, 'title': "All channels are referenced to 'ref_channel(s)"},
+        {'name': 'ref_channels', 'type': 'int_list', 'value':None, 'default':None, 'title': "If no 'groups' are specified, all channels are referenced to 'ref_channels'. \
+         If 'groups' is provided, then a list of channels to be applied to each group is expected. If 'single' reference, a list of one channel is expected."},
         {'name': 'verbose', 'type': 'bool', 'value':False, 'default':False, 'title': "If True, then the function will be verbose"}
     ]
     installation_mesg = ""  # err
 
-    def __init__(self, recording, reference='median', groups=None, ref_channel=None, verbose=False):
+    def __init__(self, recording, reference='median', groups=None, ref_channels=None, verbose=False):
         RecordingExtractor.__init__(self)
         if not isinstance(recording, RecordingExtractor):
             raise ValueError("'recording' must be a RecordingExtractor")
@@ -22,7 +23,10 @@ class CommonReferenceRecording(RecordingExtractor):
         self._recording = recording
         self._ref = reference
         self._groups = groups
-        self._ref_channel = ref_channel
+        if ref_channels is not None:
+            if len(ref_channels) == 1:
+                ref_channels = ref_channels[0]
+        self._ref_channel = ref_channels
         self.verbose = verbose
         self.copy_channel_properties(recording=self._recording)
 
@@ -117,7 +121,7 @@ class CommonReferenceRecording(RecordingExtractor):
                                            for (split_group, ref) in zip(new_groups, self._ref_channel)]))
 
 
-def common_reference(recording, reference='median', groups=None, ref_channel=None, verbose=False):
+def common_reference(recording, reference='median', groups=None, ref_channels=None, verbose=False):
     '''
     Re-references the recording extractor traces.
 
@@ -136,9 +140,9 @@ def common_reference(recording, reference='median', groups=None, ref_channel=Non
         List of lists containins the channels for splitting the reference. The CMR, CAR, or referencing with respect to
         single channels are applied group-wise. It is useful when dealing with different channel groups, e.g. multiple
         tetrodes.
-    ref_channel: int or list
-        If no 'groups' are specified, all channels are referenced to 'ref_channel'. If 'groups' is provided, then a
-        list of channels to be applied to each group is expected.
+    ref_channels: list
+        If no 'groups' are specified, all channels are referenced to 'ref_channels'. If 'groups' is provided, then a
+        list of channels to be applied to each group is expected. If 'single' reference, a list of one channel is expected.
     verbose: bool
         If True, output is verbose
 
@@ -148,5 +152,5 @@ def common_reference(recording, reference='median', groups=None, ref_channel=Non
         The re-referenced recording extractor object
     '''
     return CommonReferenceRecording(
-        recording=recording, reference=reference, groups=groups, ref_channel=ref_channel, verbose=verbose
+        recording=recording, reference=reference, groups=groups, ref_channels=ref_channels, verbose=verbose
     )


### PR DESCRIPTION
@alejoe91  I didn't change the functionality, but I thought it would be better if reference channels was always a list rather than an integer or a list (better to have one type). If the list is length 1, I just store it as an integer so your old code is compatible. This will also help with future static type checking.