### PR TITLE
Exclude units without spikes from all calculations (still a bug here)

### DIFF
--- a/spiketoolkit/validation/metric_calculator.py
+++ b/spiketoolkit/validation/metric_calculator.py
@@ -43,15 +43,20 @@ class MetricCalculator:
 
         if unit_ids is None:
             unit_ids = sorting.get_unit_ids()
-            
+        
         # only use units with spikes to avoid breaking metric calculation
-        num_spikes_per_unit = [len(sorting.get_unit_spike_train(u)) for u in unit_ids]
+        num_spikes_per_unit = [len(sorting.get_unit_spike_train(unit_id)) for unit_id in sorting.get_unit_ids()]
         sorting = ThresholdCurator(sorting=sorting, metrics_epoch=num_spikes_per_unit)
         sorting.threshold_sorting(0, 'less_or_equal')
 
-        unit_ids = sorting.get_unit_ids()
+        if unit_ids is None:
+            unit_ids = sorting.get_unit_ids()
+        else:
+            unit_ids = set(unit_ids)
+            unit_ids = list(unit_ids.intersection(sorting.get_unit_ids()))
+
         if len(unit_ids)==0:
-            raise ValueError("No spikes found.")
+            raise ValueError("No units found.")
 
         spike_times, spike_clusters = st.validation.validation_tools.get_firing_times_ids(sorting,
                                                                                           self._sampling_frequency)

--- a/spiketoolkit/validation/metric_calculator.py
+++ b/spiketoolkit/validation/metric_calculator.py
@@ -40,9 +40,6 @@ class MetricCalculator:
             self._sampling_frequency = sorting.get_sampling_frequency()
         else:
             self._sampling_frequency = sampling_frequency
-
-        if unit_ids is None:
-            unit_ids = sorting.get_unit_ids()
         
         # only use units with spikes to avoid breaking metric calculation
         num_spikes_per_unit = [len(sorting.get_unit_spike_train(unit_id)) for unit_id in sorting.get_unit_ids()]


### PR DESCRIPTION
This code still breaks when `unit_ids` is supplied. The trouble is that the metric_data is computed for all units in an extractor, regardless of `unit_ids`.