### PR TITLE
Improved filtering

### DIFF
--- a/spiketoolkit/preprocessing/bandpass_filter.py
+++ b/spiketoolkit/preprocessing/bandpass_filter.py
@@ -1,6 +1,8 @@
 from .filterrecording import FilterRecording
 import numpy as np
 from scipy import special
+import tempfile
+import spikeextractors as se
 from scipy.signal import butter, filtfilt
 
 try:
@@ -28,17 +30,28 @@ class BandpassFilterRecording(FilterRecording):
     ]
     installation_mesg = "To use the BandpassFilterRecording, install scipy: \n\n pip install scipy\n\n"  # err
 
-    def __init__(self, recording, freq_min=300, freq_max=6000, freq_wid=1000, type='fft', order=3, chunk_size=30000, cache=False):
+    def __init__(self, recording, freq_min=300, freq_max=6000, freq_wid=1000, type='fft', order=3,
+                 chunk_size=30000, cache=False):
         assert HAVE_BFR, "To use the BandpassFilterRecording, install scipy: \n\n pip install scipy\n\n"
         self._freq_min = freq_min
         self._freq_max = freq_max
         self._freq_wid = freq_wid
         self._type = type
         self._order = order
+        self._chunk_size = chunk_size
+
+        if self._type == 'butter':
+            fn = recording.get_sampling_frequency() / 2.
+            band = np.array([self._freq_min, self._freq_max]) / fn
+
+            self._b, self._a = butter(self._order, band, btype='bandpass')
+
+            if not np.all(np.abs(np.roots(self._a)) < 1):
+                raise ValueError('Filter is not stable')
+        if cache:
+            self._chunk_size = None
         FilterRecording.__init__(self, recording=recording, chunk_size=chunk_size, cache=cache)
         self.copy_channel_properties(recording)
-        if cache:
-            self._traces = self.get_traces()
 
     def filter_chunk(self, *, start_frame, end_frame):
         padding = 3000
@@ -48,28 +61,6 @@ class BandpassFilterRecording(FilterRecording):
         filtered_padded_chunk = self._do_filter(padded_chunk)
         return filtered_padded_chunk[:, start_frame - i1:end_frame - i1]
 
-    def _create_filter_kernel(self, N, sampling_frequency, freq_min, freq_max, freq_wid=1000):
-        # Matches ahb's code /matlab/processors/ms_bandpass_filter.m
-        # improved ahb, changing tanh to erf, correct -3dB pts  6/14/16
-        T = N / sampling_frequency  # total time
-        df = 1 / T  # frequency grid
-        relwid = 3.0  # relative bottom-end roll-off width param, kills low freqs by factor 1e-5.
-
-        k_inds = np.arange(0, N)
-        k_inds = np.where(k_inds <= (N + 1) / 2, k_inds, k_inds - N)
-
-        fgrid = df * k_inds
-        absf = np.abs(fgrid)
-
-        val = np.ones(fgrid.shape)
-        if freq_min != 0:
-            val = val * (1 + special.erf(relwid * (absf - freq_min) / freq_min)) / 2
-            val = np.where(np.abs(k_inds) < 0.1, 0, val)  # kill DC part exactly
-        if freq_max != 0:
-            val = val * (1 - special.erf((absf - freq_max) / freq_wid)) / 2;
-        val = np.sqrt(val)  # note sqrt of filter func to apply to spectral intensity not ampl
-        return val
-
     def _do_filter(self, chunk):
         sampling_frequency = self._recording.get_sampling_frequency()
         M = chunk.shape[0]
@@ -77,7 +68,7 @@ class BandpassFilterRecording(FilterRecording):
         # Do the actual filtering with a DFT with real input
         if self._type == 'fft':
             chunk_fft = np.fft.rfft(chunk2)
-            kernel = self._create_filter_kernel(
+            kernel = _create_filter_kernel(
                 chunk2.shape[1],
                 sampling_frequency,
                 self._freq_min, self._freq_max, self._freq_wid
@@ -86,15 +77,8 @@ class BandpassFilterRecording(FilterRecording):
             chunk_fft = chunk_fft * np.tile(kernel, (M, 1))
             chunk_filtered = np.fft.irfft(chunk_fft)
         elif self._type == 'butter':
-            fn = self.get_sampling_frequency() / 2.
-            band = np.array([self._freq_min, self._freq_max]) / fn
+            chunk_filtered = filtfilt(self._b, self._a, chunk2, axis=1)
 
-            b, a = butter(self._order, band, btype='bandpass')
-
-            if np.all(np.abs(np.roots(a)) < 1) and np.all(np.abs(np.roots(a)) < 1):
-                chunk_filtered = filtfilt(b, a, chunk2, axis=1)
-            else:
-                raise ValueError('Filter is not stable')
         return chunk_filtered
 
     def _read_chunk(self, i1, i2):
@@ -110,10 +94,35 @@ class BandpassFilterRecording(FilterRecording):
             i2b = i2
         ret = np.zeros((M, i2 - i1))
         ret[:, i1b - i1:i2b - i1] = self._recording.get_traces(start_frame=i1b, end_frame=i2b)
+
         return ret
 
 
-def bandpass_filter(recording, freq_min=300, freq_max=6000, freq_wid=1000, type='fft', order=3, chunk_size=30000, cache=False):
+def _create_filter_kernel(N, sampling_frequency, freq_min, freq_max, freq_wid=1000):
+    # Matches ahb's code /matlab/processors/ms_bandpass_filter.m
+    # improved ahb, changing tanh to erf, correct -3dB pts  6/14/16
+    T = N / sampling_frequency  # total time
+    df = 1 / T  # frequency grid
+    relwid = 3.0  # relative bottom-end roll-off width param, kills low freqs by factor 1e-5.
+
+    k_inds = np.arange(0, N)
+    k_inds = np.where(k_inds <= (N + 1) / 2, k_inds, k_inds - N)
+
+    fgrid = df * k_inds
+    absf = np.abs(fgrid)
+
+    val = np.ones(fgrid.shape)
+    if freq_min != 0:
+        val = val * (1 + special.erf(relwid * (absf - freq_min) / freq_min)) / 2
+        val = np.where(np.abs(k_inds) < 0.1, 0, val)  # kill DC part exactly
+    if freq_max != 0:
+        val = val * (1 - special.erf((absf - freq_max) / freq_wid)) / 2;
+    val = np.sqrt(val)  # note sqrt of filter func to apply to spectral intensity not ampl
+    return val
+
+
+def bandpass_filter(recording, freq_min=300, freq_max=6000, freq_wid=1000, type='fft', order=3,
+                    chunk_size=30000, cache=False):
     '''
     Performs a lazy filter on the recording extractor traces.
 
@@ -142,7 +151,7 @@ def bandpass_filter(recording, freq_min=300, freq_max=6000, freq_wid=1000, type=
     filter_recording: BandpassFilterRecording
         The filtered recording extractor object
     '''
-    return BandpassFilterRecording(
+    bpf_recording = BandpassFilterRecording(
         recording=recording,
         freq_min=freq_min,
         freq_max=freq_max,
@@ -152,3 +161,15 @@ def bandpass_filter(recording, freq_min=300, freq_max=6000, freq_wid=1000, type=
         chunk_size=chunk_size,
         cache=cache
     )
+    if cache:
+        tmp_file = tempfile.NamedTemporaryFile(prefix="filt", suffix=".dat")
+        dtype = bpf_recording.get_traces(start_frame=0, end_frame=10).dtype
+        se.write_to_binary_dat_format(bpf_recording, save_path=str(tmp_file.name))
+        bin_recording = se.BinDatRecordingExtractor(str(tmp_file.name), numchan=bpf_recording.get_num_channels(),
+                                                    recording_channels=bpf_recording.get_channel_ids(),
+                                                    sampling_frequency=bpf_recording.get_sampling_frequency(),
+                                                    dtype=dtype)
+        bin_recording.copy_channel_properties(bpf_recording)
+        return bin_recording
+    else:
+        return bpf_recording

--- a/spiketoolkit/preprocessing/bandpass_filter.py
+++ b/spiketoolkit/preprocessing/bandpass_filter.py
@@ -1,12 +1,10 @@
 from .filterrecording import FilterRecording
 import numpy as np
 from scipy import special
-import tempfile
 import spikeextractors as se
-from scipy.signal import butter, filtfilt
 
 try:
-    from scipy.signal import butter, filtfilt
+    import scipy.signal as ss
     HAVE_BFR = True
 except ImportError:
     HAVE_BFR = False
@@ -44,13 +42,13 @@ class BandpassFilterRecording(FilterRecording):
             fn = recording.get_sampling_frequency() / 2.
             band = np.array([self._freq_min, self._freq_max]) / fn
 
-            self._b, self._a = butter(self._order, band, btype='bandpass')
+            self._b, self._a = ss.butter(self._order, band, btype='bandpass')
 
             if not np.all(np.abs(np.roots(self._a)) < 1):
                 raise ValueError('Filter is not stable')
         if cache:
             self._chunk_size = None
-        FilterRecording.__init__(self, recording=recording, chunk_size=chunk_size, cache=cache)
+        FilterRecording.__init__(self, recording=recording, chunk_size=chunk_size)
         self.copy_channel_properties(recording)
 
     def filter_chunk(self, *, start_frame, end_frame):
@@ -77,7 +75,7 @@ class BandpassFilterRecording(FilterRecording):
             chunk_fft = chunk_fft * np.tile(kernel, (M, 1))
             chunk_filtered = np.fft.irfft(chunk_fft)
         elif self._type == 'butter':
-            chunk_filtered = filtfilt(self._b, self._a, chunk2, axis=1)
+            chunk_filtered = ss.filtfilt(self._b, self._a, chunk2, axis=1)
 
         return chunk_filtered
 

--- a/spiketoolkit/preprocessing/bandpass_filter.py
+++ b/spiketoolkit/preprocessing/bandpass_filter.py
@@ -162,14 +162,6 @@ def bandpass_filter(recording, freq_min=300, freq_max=6000, freq_wid=1000, type=
         cache=cache
     )
     if cache:
-        tmp_file = tempfile.NamedTemporaryFile(prefix="filt", suffix=".dat")
-        dtype = bpf_recording.get_traces(start_frame=0, end_frame=10).dtype
-        se.write_to_binary_dat_format(bpf_recording, save_path=str(tmp_file.name))
-        bin_recording = se.BinDatRecordingExtractor(str(tmp_file.name), numchan=bpf_recording.get_num_channels(),
-                                                    recording_channels=bpf_recording.get_channel_ids(),
-                                                    sampling_frequency=bpf_recording.get_sampling_frequency(),
-                                                    dtype=dtype)
-        bin_recording.copy_channel_properties(bpf_recording)
-        return bin_recording
+        return se.CacheRecordingExtractor(bpf_recording)
     else:
         return bpf_recording

--- a/spiketoolkit/preprocessing/filterrecording.py
+++ b/spiketoolkit/preprocessing/filterrecording.py
@@ -32,9 +32,7 @@ class FilterRecording(RecordingExtractor):
             end_frame = self.get_num_frames()
         if channel_ids is None:
             channel_ids = self.get_channel_ids()
-        if self._cache and self._traces is not None:
-            return self._traces[channel_ids, start_frame:end_frame]
-        else:
+        if self._chunk_size is not None:
             ich1 = int(start_frame / self._chunk_size)
             ich2 = int((end_frame - 1) / self._chunk_size)
             filtered_chunk_list = []
@@ -50,7 +48,10 @@ class FilterRecording(RecordingExtractor):
                     end0 = self._chunk_size
                 chan_idx = [self.get_channel_ids().index(chan) for chan in channel_ids]
                 filtered_chunk_list.append(filtered_chunk0[chan_idx, start0:end0])
-            return np.concatenate(filtered_chunk_list, axis=1)
+            filtered_chunk =  np.concatenate(filtered_chunk_list, axis=1)
+        else:
+            filtered_chunk = self.filter_chunk(start_frame=0, end_frame=self._recording.get_num_frames())
+        return filtered_chunk
 
     @abstractmethod
     def filter_chunk(self, *, start_frame, end_frame):

--- a/spiketoolkit/preprocessing/filterrecording.py
+++ b/spiketoolkit/preprocessing/filterrecording.py
@@ -5,13 +5,12 @@ from spikeextractors import RecordingExtractor
 
 
 class FilterRecording(RecordingExtractor):
-    def __init__(self, recording, chunk_size=10000, cache=False):
+    def __init__(self, recording, chunk_size=10000):
         if not isinstance(recording, RecordingExtractor):
             raise ValueError("'recording' must be a RecordingExtractor")
         self._recording = recording
         self._chunk_size = chunk_size
         self._filtered_chunk_cache = FilteredChunkCache()
-        self._cache = cache
         self._traces = None
         se.RecordingExtractor.__init__(self)
         self.copy_channel_properties(recording)

--- a/spiketoolkit/preprocessing/notch_filter.py
+++ b/spiketoolkit/preprocessing/notch_filter.py
@@ -1,9 +1,9 @@
 from .filterrecording import FilterRecording
+import spikeextractors as se
 import numpy as np
 
 try:
-    from scipy import special
-    from scipy.signal import iirnotch, filtfilt
+    import scipy.signal as ss
     HAVE_NFR = True
 except ImportError:
     HAVE_NFR = False
@@ -26,10 +26,15 @@ class NotchFilterRecording(FilterRecording):
         assert HAVE_NFR, "To use the NotchFilterRecording, install scipy: \n\n pip install scipy\n\n"
         self._freq = freq
         self._q = q
-        FilterRecording.__init__(self, recording=recording, chunk_size=chunk_size, cache=cache)
-        self.copy_channel_properties(recording)
+        fn = 0.5 * float(self.get_sampling_frequency())
+        self._b, self._a = ss.iirnotch(self._freq / fn, self._q)
+
+        if not np.all(np.abs(np.roots(self._a)) < 1):
+            raise ValueError('Filter is not stable')
         if cache:
-            self._traces = self.get_traces()
+            self._chunk_size = None
+        FilterRecording.__init__(self, recording=recording, chunk_size=chunk_size)
+        self.copy_channel_properties(recording)
 
     def filter_chunk(self, *, start_frame, end_frame):
         padding = 3000
@@ -39,40 +44,9 @@ class NotchFilterRecording(FilterRecording):
         filtered_padded_chunk = self._do_filter(padded_chunk)
         return filtered_padded_chunk[:, start_frame - i1:end_frame - i1]
 
-    def _create_filter_kernel(self, N, sampling_frequency, freq_min, freq_max, freq_wid=1000):
-        # Matches ahb's code /matlab/processors/ms_bandpass_filter.m
-        # improved ahb, changing tanh to erf, correct -3dB pts  6/14/16
-        T = N / sampling_frequency  # total time
-        df = 1 / T  # frequency grid
-        relwid = 3.0  # relative bottom-end roll-off width param, kills low freqs by factor 1e-5.
-
-        k_inds = np.arange(0, N)
-        k_inds = np.where(k_inds <= (N + 1) / 2, k_inds, k_inds - N)
-
-        fgrid = df * k_inds
-        absf = np.abs(fgrid)
-
-        val = np.ones(fgrid.shape)
-        if freq_min != 0:
-            val = val * (1 + special.erf(relwid * (absf - freq_min) / freq_min)) / 2
-            val = np.where(np.abs(k_inds) < 0.1, 0, val)  # kill DC part exactly
-        if freq_max != 0:
-            val = val * (1 - special.erf((absf - freq_max) / freq_wid)) / 2;
-        val = np.sqrt(val)  # note sqrt of filter func to apply to spectral intensity not ampl
-        return val
-
     def _do_filter(self, chunk):
-        sampling_frequency = self._recording.get_sampling_frequency()
-        M = chunk.shape[0]
-        chunk2 = chunk
-        fn = 0.5 * float(self.get_sampling_frequency())
-        # Do the actual filtering with a DFT with real input
-        b, a = iirnotch(self._freq / fn, self._q)
+        chunk_filtered = ss.filtfilt(self._b, self._a, chunk, axis=1)
 
-        if np.all(np.abs(np.roots(a)) < 1) and np.all(np.abs(np.roots(a)) < 1):
-            chunk_filtered = filtfilt(b, a, chunk2, axis=1)
-        else:
-            raise ValueError('Filter is not stable')
         return chunk_filtered
 
     def _read_chunk(self, i1, i2):
@@ -114,10 +88,14 @@ def notch_filter(recording, freq=3000, q=30, chunk_size=30000, cache=False):
         The notch-filtered recording extractor object
 
     '''
-    return NotchFilterRecording(
+    notch_recording =  NotchFilterRecording(
         recording=recording,
         freq=freq,
         q=q,
         chunk_size=chunk_size,
         cache=cache,
     )
+    if cache:
+        return se.CacheRecordingExtractor(notch_recording)
+    else:
+        return notch_recording

--- a/spiketoolkit/preprocessing/notch_filter.py
+++ b/spiketoolkit/preprocessing/notch_filter.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     HAVE_NFR = False
 
+
 class NotchFilterRecording(FilterRecording):
 
     preprocessor_name = 'NotchFilter'
@@ -26,7 +27,7 @@ class NotchFilterRecording(FilterRecording):
         assert HAVE_NFR, "To use the NotchFilterRecording, install scipy: \n\n pip install scipy\n\n"
         self._freq = freq
         self._q = q
-        fn = 0.5 * float(self.get_sampling_frequency())
+        fn = 0.5 * float(recording.get_sampling_frequency())
         self._b, self._a = ss.iirnotch(self._freq / fn, self._q)
 
         if not np.all(np.abs(np.roots(self._a)) < 1):

--- a/spiketoolkit/preprocessing/whiten.py
+++ b/spiketoolkit/preprocessing/whiten.py
@@ -17,7 +17,7 @@ class WhitenRecording(FilterRecording):
     def __init__(self, recording, chunk_size=30000, cache=False):
         self._recording = recording
         self._whitening_matrix = self._compute_whitening_matrix()
-        FilterRecording.__init__(self, recording=recording, chunk_size=chunk_size, cache=cache)
+        FilterRecording.__init__(self, recording=recording, chunk_size=chunk_size)
 
     def _get_random_data_for_whitening(self, num_chunks=50, chunk_size=500):
         N = self._recording.get_num_frames()

--- a/spiketoolkit/tests/test_preprocessing.py
+++ b/spiketoolkit/tests/test_preprocessing.py
@@ -25,6 +25,13 @@ def test_bandpass_filter():
     assert check_signal_power_signal1_below_signal2(rec_sci.get_traces(), rec.get_traces(), freq_range=[6000, 10000],
                                                     fs=rec.get_sampling_frequency())
 
+    rec_cache = bandpass_filter(rec, freq_min=3000, freq_max=6000, type='butter', order=3, cache=True)
+
+    assert check_signal_power_signal1_below_signal2(rec_cache.get_traces(), rec.get_traces(), freq_range=[1000, 3000],
+                                                    fs=rec.get_sampling_frequency())
+    assert check_signal_power_signal1_below_signal2(rec_cache.get_traces(), rec.get_traces(), freq_range=[6000, 10000],
+                                                    fs=rec.get_sampling_frequency())
+
 
 @pytest.mark.implemented
 def test_blank_saturation():


### PR DESCRIPTION
- moved out the butter filter creation in the init
- cache option now filters all the data and dumps it into a bin recording

Should fix:
https://github.com/SpikeInterface/spiketoolkit/issues/249  https://github.com/SpikeInterface/spiketoolkit/issues/248

I tested the performance on 120s 16 channels:

**Default filter**
```
rec_f = st.preprocessing.bandpass_filter(rec)

# filter all traces
t_start = time.time()
rec_f.get_traces()
print(time.time() - t_start)

2.017151117324829 s

# get waveform (before internal caching)
t_start = time.time()
wf1 = st.postprocessing.get_unit_waveforms(rec_f, sort)
print(time.time() - t_start)

2.023608446121216 s
```

**Cache** - the filtering is performed at initialization and dumped to file (a bit slower)
```
# initialization + filter + save
t_start = time.time()
rec_c = st.preprocessing.bandpass_filter(rec, cache=True)
print(time.time() - t_start)

3.8165152072906494 s

# get waveform 
t_start = time.time()
wf1 = st.postprocessing.get_unit_waveforms(rec_c, sort)
print(time.time() - t_start)

0.08617234230041504 s
```

@samuelgarcia @teristam @magland 
I think this will speed up **A LOT** the waveform retrieval. If you agree to this design I will propagate the cache option to all other preprocessors.