### PR TITLE
Fix metrics when max_num_spikes and pca is less than inf

### DIFF
--- a/spiketoolkit/curation/curationsortingextractor.py
+++ b/spiketoolkit/curation/curationsortingextractor.py
@@ -41,12 +41,12 @@ class CurationSortingExtractor(SortingExtractor):
         valid_unit_id = False
         spike_train = np.asarray([])
         for root in self._roots:
-            if (root.unit_id == unit_id):
+            if root.unit_id == unit_id:
                 valid_unit_id = True
                 full_spike_train = root.get_spike_train()
                 inds = np.where((start_frame <= full_spike_train) & (full_spike_train < end_frame))
                 spike_train = full_spike_train[inds]
-        if (valid_unit_id):
+        if valid_unit_id:
             return spike_train
         else:
             raise ValueError(str(unit_id) + " is an invalid unit id")
@@ -66,7 +66,7 @@ class CurationSortingExtractor(SortingExtractor):
         for i in range(len(self._roots)):
             root_id = self._roots[i].unit_id
             root_ids.append(root_id)
-        if (unit_id in root_ids):
+        if unit_id in root_ids:
             root_index = root_ids.index(unit_id)
             print(self._roots[root_index])
         else:
@@ -80,14 +80,14 @@ class CurationSortingExtractor(SortingExtractor):
         unit_ids: list
             The unit ids to be excluded
         '''
-        if (len(unit_ids) == 0):
+        if len(unit_ids) == 0:
             return
         root_ids = []
         for i in range(len(self._roots)):
             root_id = self._roots[i].unit_id
             root_ids.append(root_id)
 
-        if (set(unit_ids).issubset(set(root_ids)) and len(unit_ids) > 0):
+        if set(unit_ids).issubset(set(root_ids)) and len(unit_ids) > 0:
             indices_to_be_deleted = []
             for unit_id in unit_ids:
                 root_index = root_ids.index(unit_id)
@@ -107,7 +107,7 @@ class CurationSortingExtractor(SortingExtractor):
         unit_ids: list
             The unit ids to be merged
         '''
-        if (len(unit_ids) <= 1):
+        if len(unit_ids) <= 1:
             return
 
         root_ids = []
@@ -116,7 +116,7 @@ class CurationSortingExtractor(SortingExtractor):
             root_ids.append(root_id)
 
         indices_to_be_deleted = []
-        if (set(unit_ids).issubset(set(root_ids))):
+        if set(unit_ids).issubset(set(root_ids)):
             # Find all unique feature names and create all feature lists
             all_feature_names = []
             for unit_id in unit_ids:
@@ -174,7 +174,7 @@ class CurationSortingExtractor(SortingExtractor):
             root_id = self._roots[i].unit_id
             root_ids.append(root_id)
 
-        if (unit_id in root_ids):
+        if unit_id in root_ids:
             indices_1 = np.sort(np.asarray(list(set(indices))))
 
             root_index = root_ids.index(unit_id)
@@ -226,7 +226,7 @@ class CurationSortingExtractor(SortingExtractor):
         for i in range(len(self._roots)):
             root_id = self._roots[i].unit_id
             root_ids.append(root_id)
-        if (unit_id in root_ids):
+        if unit_id in root_ids:
             root_index = root_ids.index(unit_id)
             print(self._roots[root_index])
         else:
@@ -253,7 +253,7 @@ class Unit(object):
         return self.children
 
     def __str__(self, level=0):
-        if (level == 0):
+        if level == 0:
             ret = "\t" * (max(level - 1, 0)) + repr(self.unit_id) + "\n"
         else:
             ret = "\t" * (max(level - 1, 0)) + "^-------" + repr(self.unit_id) + "\n"

--- a/spiketoolkit/curation/curationsortingextractor.py
+++ b/spiketoolkit/curation/curationsortingextractor.py
@@ -12,7 +12,7 @@ class CurationSortingExtractor(SortingExtractor):
         self._original_unit_ids = list(np.copy(parent_sorting.get_unit_ids()))
         self._all_ids = list(np.copy(parent_sorting.get_unit_ids()))
 
-        #Create and store roots with original unit ids and cached spiketrains
+        # Create and store roots with original unit ids and cached spiketrains
         self._roots = []
         for unit_id in self._original_unit_ids:
             root = Unit(unit_id)
@@ -41,12 +41,12 @@ class CurationSortingExtractor(SortingExtractor):
         valid_unit_id = False
         spike_train = np.asarray([])
         for root in self._roots:
-            if(root.unit_id == unit_id):
+            if (root.unit_id == unit_id):
                 valid_unit_id = True
                 full_spike_train = root.get_spike_train()
                 inds = np.where((start_frame <= full_spike_train) & (full_spike_train < end_frame))
                 spike_train = full_spike_train[inds]
-        if(valid_unit_id):
+        if (valid_unit_id):
             return spike_train
         else:
             raise ValueError(str(unit_id) + " is an invalid unit id")
@@ -66,12 +66,11 @@ class CurationSortingExtractor(SortingExtractor):
         for i in range(len(self._roots)):
             root_id = self._roots[i].unit_id
             root_ids.append(root_id)
-        if(unit_id in root_ids):
+        if (unit_id in root_ids):
             root_index = root_ids.index(unit_id)
             print(self._roots[root_index])
         else:
             raise ValueError("invalid unit id")
-
 
     def exclude_units(self, unit_ids):
         '''This function deletes roots from the curation tree according to the given unit_ids
@@ -81,21 +80,21 @@ class CurationSortingExtractor(SortingExtractor):
         unit_ids: list
             The unit ids to be excluded
         '''
-        if(len(unit_ids) == 0):
+        if (len(unit_ids) == 0):
             return
         root_ids = []
         for i in range(len(self._roots)):
             root_id = self._roots[i].unit_id
             root_ids.append(root_id)
 
-        if(set(unit_ids).issubset(set(root_ids)) and len(unit_ids) > 0):
+        if (set(unit_ids).issubset(set(root_ids)) and len(unit_ids) > 0):
             indices_to_be_deleted = []
             for unit_id in unit_ids:
                 root_index = root_ids.index(unit_id)
                 indices_to_be_deleted.append(root_index)
                 if unit_id in self._unit_features:
                     del self._unit_features[unit_id]
-            self._roots = [self._roots[i] for i,_ in enumerate(root_ids) if i not in indices_to_be_deleted]
+            self._roots = [self._roots[i] for i, _ in enumerate(root_ids) if i not in indices_to_be_deleted]
         else:
             raise ValueError(str(unit_ids) + " has one or more invalid unit ids")
 
@@ -108,7 +107,7 @@ class CurationSortingExtractor(SortingExtractor):
         unit_ids: list
             The unit ids to be merged
         '''
-        if(len(unit_ids) <= 1):
+        if (len(unit_ids) <= 1):
             return
 
         root_ids = []
@@ -117,8 +116,8 @@ class CurationSortingExtractor(SortingExtractor):
             root_ids.append(root_id)
 
         indices_to_be_deleted = []
-        if(set(unit_ids).issubset(set(root_ids))):
-            #Find all unique feature names and create all feature lists
+        if (set(unit_ids).issubset(set(root_ids))):
+            # Find all unique feature names and create all feature lists
             all_feature_names = []
             for unit_id in unit_ids:
                 feature_names = self.get_unit_spike_feature_names(unit_id)
@@ -132,7 +131,7 @@ class CurationSortingExtractor(SortingExtractor):
             for i in range(len(shared_feature_names)):
                 shared_features.append([])
 
-            new_root_id = max(self._all_ids)+1
+            new_root_id = max(self._all_ids) + 1
             self._all_ids.append(new_root_id)
             new_root = Unit(new_root_id)
             all_spike_trains = []
@@ -144,17 +143,18 @@ class CurationSortingExtractor(SortingExtractor):
                     features = self.get_unit_spike_features(unit_id, feature_name)
                     shared_features[i].append(features)
                 del self._unit_features[unit_id]
-                self._roots[root_index].set_spike_train(np.asarray([])) #clear spiketrain
+                self._roots[root_index].set_spike_train(np.asarray([]))  # clear spiketrain
                 indices_to_be_deleted.append(root_index)
 
             all_spike_trains = np.concatenate(all_spike_trains)
             sort_indices = np.argsort(all_spike_trains)
             new_root.set_spike_train(np.asarray(all_spike_trains)[sort_indices])
             del all_spike_trains
-            self._roots = [self._roots[i] for i,_ in enumerate(root_ids) if i not in indices_to_be_deleted]
+            self._roots = [self._roots[i] for i, _ in enumerate(root_ids) if i not in indices_to_be_deleted]
             self._roots.append(new_root)
             for i, feature_name in enumerate(shared_feature_names):
-                self.set_unit_spike_features(new_root_id, feature_name, np.concatenate(shared_features[i])[sort_indices])
+                self.set_unit_spike_features(new_root_id, feature_name,
+                                             np.concatenate(shared_features[i])[sort_indices])
         else:
             raise ValueError(str(unit_ids) + " has one or more invalid unit ids")
 
@@ -174,7 +174,7 @@ class CurationSortingExtractor(SortingExtractor):
             root_id = self._roots[i].unit_id
             root_ids.append(root_id)
 
-        if(unit_id in root_ids):
+        if (unit_id in root_ids):
             indices_1 = np.sort(np.asarray(list(set(indices))))
 
             root_index = root_ids.index(unit_id)
@@ -190,13 +190,13 @@ class CurationSortingExtractor(SortingExtractor):
             spike_train_2 = original_spike_train[indices_2]
             del original_spike_train
 
-            new_root_1_id = max(self._all_ids)+1
+            new_root_1_id = max(self._all_ids) + 1
             self._all_ids.append(new_root_1_id)
             new_root_1 = Unit(new_root_1_id)
             new_root_1.add_child(new_child)
             new_root_1.set_spike_train(spike_train_1)
 
-            new_root_2_id = max(self._all_ids)+1
+            new_root_2_id = max(self._all_ids) + 1
             self._all_ids.append(new_root_2_id)
             new_root_2 = Unit(new_root_2_id)
             new_root_2.add_child(new_child)
@@ -226,7 +226,7 @@ class CurationSortingExtractor(SortingExtractor):
         for i in range(len(self._roots)):
             root_id = self._roots[i].unit_id
             root_ids.append(root_id)
-        if(unit_id in root_ids):
+        if (unit_id in root_ids):
             root_index = root_ids.index(unit_id)
             print(self._roots[root_index])
         else:
@@ -253,10 +253,10 @@ class Unit(object):
         return self.children
 
     def __str__(self, level=0):
-        if(level == 0):
-            ret = "\t"*(max(level-1, 0)) +repr(self.unit_id)+ "\n"
+        if (level == 0):
+            ret = "\t" * (max(level - 1, 0)) + repr(self.unit_id) + "\n"
         else:
-            ret = "\t"*(max(level-1, 0)) + "^-------" +repr(self.unit_id)+ "\n"
+            ret = "\t" * (max(level - 1, 0)) + "^-------" + repr(self.unit_id) + "\n"
         for child in self.children:
-            ret += child.__str__(level+1)
+            ret += child.__str__(level + 1)
         return ret

--- a/spiketoolkit/curation/threshold_firing_rate.py
+++ b/spiketoolkit/curation/threshold_firing_rate.py
@@ -3,16 +3,19 @@ import spiketoolkit as st
 
 
 class ThresholdFiringRate(ThresholdCurator):
-
     curator_name = 'ThresholdFiringRate'
     installed = True  # check at class level if installed or not
     curator_gui_params = [
-        {'name': 'threshold', 'type': 'float', 'value':15.0, 'default':15.0, 'title': "The threshold for the given metric."},
-        {'name': 'threshold_sign', 'type': 'str', 'value':'greater', 'default':'greater', 'title': "If 'less', will threshold any metric less than the given threshold. If 'greater', will threshold any metric greater than the given threshold."},
+        {'name': 'threshold', 'type': 'float', 'value': 15.0, 'default': 15.0,
+         'title': "The threshold for the given metric."},
+        {'name': 'threshold_sign', 'type': 'str', 'value': 'greater', 'default': 'greater',
+         'title': "If 'less', will threshold any metric less than the given threshold. "
+                  "If 'greater', will threshold any metric greater than the given threshold."},
     ]
-    installation_mesg = "" # err
+    installation_mesg = ""  # err
 
-    def __init__(self, sorting, threshold=15.0, threshold_sign='greater', sampling_frequency=None, metric_calculator=None):
+    def __init__(self, sorting, threshold=15.0, threshold_sign='greater', sampling_frequency=None,
+                 metric_calculator=None):
         metric_name = 'firing_rate'
         if sampling_frequency is None and sorting.get_sampling_frequency() is None:
             raise ValueError("Please pass in a sampling frequency (your SortingExtractor does not have one specified)")
@@ -21,20 +24,22 @@ class ThresholdFiringRate(ThresholdCurator):
         else:
             self._sampling_frequency = sampling_frequency
         if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=self._sampling_frequency, \
+            self._metric_calculator = st.validation.MetricCalculator(sorting,
+                                                                     sampling_frequency=self._sampling_frequency,
                                                                      unit_ids=None, epoch_tuples=None, epoch_names=None)
             self._metric_calculator.compute_firing_rates()
         else:
             self._metric_calculator = metric_calculator
             if metric_name not in self._metric_calculator.get_metrics_dict().keys():
                 self._metric_calculator.compute_firing_rates()
-        firing_rates_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0] 
+        firing_rates_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0]
 
         ThresholdCurator.__init__(self, sorting=sorting, metrics_epoch=firing_rates_epoch)
         self.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
 
 
-def threshold_firing_rate(sorting, threshold=15.0, threshold_sign='greater', sampling_frequency=None, metric_calculator=None):
+def threshold_firing_rate(sorting, threshold=15.0, threshold_sign='greater', sampling_frequency=None,
+                          metric_calculator=None):
     '''
     Excludes units based on firing rate.
 
@@ -60,9 +65,9 @@ def threshold_firing_rate(sorting, threshold=15.0, threshold_sign='greater', sam
 
     '''
     return ThresholdFiringRate(
-        sorting=sorting, 
-        threshold=threshold, 
-        threshold_sign=threshold_sign, 
+        sorting=sorting,
+        threshold=threshold,
+        threshold_sign=threshold_sign,
         sampling_frequency=sampling_frequency,
         metric_calculator=metric_calculator
     )

--- a/spiketoolkit/curation/threshold_isi_violations.py
+++ b/spiketoolkit/curation/threshold_isi_violations.py
@@ -3,16 +3,20 @@ import spiketoolkit as st
 
 
 class ThresholdISIViolations(ThresholdCurator):
-
     curator_name = 'ThresholdISIViolations'
     installed = True  # check at class level if installed or not
     curator_gui_params = [
-        {'name': 'threshold', 'type': 'float', 'value':5.0, 'default':5.0, 'title': "The threshold for the given metric."},
-        {'name': 'threshold_sign', 'type': 'str', 'value':'greater', 'default':'greater', 'title': "If 'less', will threshold any metric less than the given threshold. If 'greater', will threshold any metric greater than the given threshold."},
-        {'name': 'isi_threshold', 'type': 'float', 'value':0.0015, 'default':0.0015, 'title': "ISI threshold for calculating violations"},
-        {'name': 'min_isi', 'type': 'float', 'value':0.000166, 'default':0.000166, 'title': "Min ISI for calculating violations"},
+        {'name': 'threshold', 'type': 'float', 'value': 5.0, 'default': 5.0,
+         'title': "The threshold for the given metric."},
+        {'name': 'threshold_sign', 'type': 'str', 'value': 'greater', 'default': 'greater',
+         'title': "If 'less', will threshold any metric less than the given threshold. "
+                  "If 'greater', will threshold any metric greater than the given threshold."},
+        {'name': 'isi_threshold', 'type': 'float', 'value': 0.0015, 'default': 0.0015,
+         'title': "ISI threshold for calculating violations"},
+        {'name': 'min_isi', 'type': 'float', 'value': 0.000166, 'default': 0.000166,
+         'title': "Min ISI for calculating violations"},
     ]
-    installation_mesg = "" # err
+    installation_mesg = ""  # err
 
     def __init__(self, sorting, threshold=5.0, threshold_sign='greater', isi_threshold=0.0015, min_isi=0.000166, \
                  sampling_frequency=None, metric_calculator=None):
@@ -24,25 +28,22 @@ class ThresholdISIViolations(ThresholdCurator):
         else:
             self._sampling_frequency = sampling_frequency
         if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=self._sampling_frequency, \
+            self._metric_calculator = st.validation.MetricCalculator(sorting,
+                                                                     sampling_frequency=self._sampling_frequency,
                                                                      unit_ids=None, epoch_tuples=None, epoch_names=None)
             self._metric_calculator.compute_isi_violations(isi_threshold=isi_threshold, min_isi=min_isi)
         else:
             self._metric_calculator = metric_calculator
             if metric_name not in self._metric_calculator.get_metrics_dict().keys():
                 self._metric_calculator.compute_isi_violations(isi_threshold=isi_threshold, min_isi=min_isi)
-        isi_violations_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0]  
+        isi_violations_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0]
 
         ThresholdCurator.__init__(self, sorting=sorting, metrics_epoch=isi_violations_epoch)
         self.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
 
-        
-        
 
-
-
-def threshold_isi_violations(sorting, threshold=5.0, threshold_sign='greater', isi_threshold=0.0015, min_isi=0.000166, \
-                                 sampling_frequency=None, metric_calculator=None):
+def threshold_isi_violations(sorting, threshold=5.0, threshold_sign='greater', isi_threshold=0.0015, min_isi=0.000166,
+                             sampling_frequency=None, metric_calculator=None):
     '''
     Excludes units based on isi violations.
 
@@ -72,11 +73,11 @@ def threshold_isi_violations(sorting, threshold=5.0, threshold_sign='greater', i
 
     '''
     return ThresholdISIViolations(
-        sorting=sorting, 
-        threshold=threshold, 
-        threshold_sign=threshold_sign, 
-        isi_threshold=isi_threshold, 
-        min_isi=min_isi, \
-        sampling_frequency=sampling_frequency, 
+        sorting=sorting,
+        threshold=threshold,
+        threshold_sign=threshold_sign,
+        isi_threshold=isi_threshold,
+        min_isi=min_isi,
+        sampling_frequency=sampling_frequency,
         metric_calculator=metric_calculator
     )

--- a/spiketoolkit/curation/threshold_num_spikes.py
+++ b/spiketoolkit/curation/threshold_num_spikes.py
@@ -1,15 +1,20 @@
 from .thresholdcurator import ThresholdCurator
 import spiketoolkit as st
 
-class ThresholdNumSpikes(ThresholdCurator):
 
+class ThresholdNumSpikes(ThresholdCurator):
     curator_name = 'ThresholdNumSpikes'
     installed = True  # check at class level if installed or not
     curator_gui_params = [
-        {'name': 'threshold', 'type': 'float', 'value':100, 'default':100, 'title': "The threshold for the given metric."},
-        {'name': 'threshold_sign', 'type': 'str', 'value':'less', 'default':'less', 'title': "If 'less', will threshold any metric less than the given threshold. If 'less_or_equal', will threshold any metric less than or equal to the given threshold. If 'greater', will threshold any metric greater than the given threshold. If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold."},
+        {'name': 'threshold', 'type': 'float', 'value': 100, 'default': 100, 'title':
+            "The threshold for the given metric."},
+        {'name': 'threshold_sign', 'type': 'str', 'value': 'less', 'default': 'less',
+         'title': "If 'less', will threshold any metric less than the given threshold. "
+                  "If 'less_or_equal', will threshold any metric less than or equal to the given threshold. "
+                  "If 'greater', will threshold any metric greater than the given threshold. "
+                  "If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold."},
     ]
-    installation_mesg = "" # err
+    installation_mesg = ""  # err
 
     def __init__(self, sorting, threshold=100, threshold_sign='less', sampling_frequency=None, metric_calculator=None):
         metric_name = 'num_spikes'
@@ -20,20 +25,22 @@ class ThresholdNumSpikes(ThresholdCurator):
         else:
             self._sampling_frequency = sampling_frequency
         if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=self._sampling_frequency, \
+            self._metric_calculator = st.validation.MetricCalculator(sorting,
+                                                                     sampling_frequency=self._sampling_frequency,
                                                                      unit_ids=None, epoch_tuples=None, epoch_names=None)
             self._metric_calculator.compute_num_spikes()
         else:
             self._metric_calculator = metric_calculator
             if metric_name not in self._metric_calculator.get_metrics_dict().keys():
                 self._metric_calculator.compute_num_spikes()
-        num_spikes_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0] 
+        num_spikes_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0]
 
         ThresholdCurator.__init__(self, sorting=sorting, metrics_epoch=num_spikes_epoch)
         self.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
 
 
-def threshold_num_spikes(sorting, threshold=100, threshold_sign='less', sampling_frequency=None, metric_calculator=None):
+def threshold_num_spikes(sorting, threshold=100, threshold_sign='less', sampling_frequency=None,
+                         metric_calculator=None):
     '''
     Excludes units based on number of spikes.
 
@@ -59,9 +66,9 @@ def threshold_num_spikes(sorting, threshold=100, threshold_sign='less', sampling
 
     '''
     return ThresholdNumSpikes(
-        sorting=sorting, 
-        threshold=threshold, 
-        threshold_sign=threshold_sign, 
+        sorting=sorting,
+        threshold=threshold,
+        threshold_sign=threshold_sign,
         sampling_frequency=sampling_frequency,
         metric_calculator=metric_calculator
     )

--- a/spiketoolkit/curation/threshold_presence_ratio.py
+++ b/spiketoolkit/curation/threshold_presence_ratio.py
@@ -3,14 +3,16 @@ import spiketoolkit as st
 
 
 class ThresholdPresenceRatio(ThresholdCurator):
-
     curator_name = 'ThresholdPresenceRatio'
     installed = True  # check at class level if installed or not
     curator_gui_params = [
-        {'name': 'threshold', 'type': 'float', 'value':.50, 'default':.50, 'title': "The threshold for the given metric."},
-        {'name': 'threshold_sign', 'type': 'str', 'value':'less', 'default':'less', 'title': "If 'less', will threshold any metric less than the given threshold. If 'greater', will threshold any metric greater than the given threshold."},
+        {'name': 'threshold', 'type': 'float', 'value': .50, 'default': .50, 'title':
+            "The threshold for the given metric."},
+        {'name': 'threshold_sign', 'type': 'str', 'value': 'less', 'default': 'less',
+         'title': "If 'less', will threshold any metric less than the given threshold. "
+                  "If 'greater', will threshold any metric greater than the given threshold."},
     ]
-    installation_mesg = "" # err
+    installation_mesg = ""  # err
 
     def __init__(self, sorting, threshold=.50, threshold_sign='less', sampling_frequency=None, metric_calculator=None):
         metric_name = 'presence_ratio'
@@ -21,20 +23,22 @@ class ThresholdPresenceRatio(ThresholdCurator):
         else:
             self._sampling_frequency = sampling_frequency
         if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=self._sampling_frequency, \
+            self._metric_calculator = st.validation.MetricCalculator(sorting,
+                                                                     sampling_frequency=self._sampling_frequency,
                                                                      unit_ids=None, epoch_tuples=None, epoch_names=None)
             self._metric_calculator.compute_presence_ratios()
         else:
             self._metric_calculator = metric_calculator
             if metric_name not in self._metric_calculator.get_metrics_dict().keys():
                 self._metric_calculator.compute_presence_ratios()
-        presence_ratios_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0] 
+        presence_ratios_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0]
 
         ThresholdCurator.__init__(self, sorting=sorting, metrics_epoch=presence_ratios_epoch)
         self.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
 
 
-def threshold_presence_ratio(sorting, threshold=.50, threshold_sign='less', sampling_frequency=None, metric_calculator=None):
+def threshold_presence_ratio(sorting, threshold=.50, threshold_sign='less', sampling_frequency=None,
+                             metric_calculator=None):
     '''
     Excludes units based on presence ratios.
 
@@ -60,9 +64,9 @@ def threshold_presence_ratio(sorting, threshold=.50, threshold_sign='less', samp
 
     '''
     return ThresholdPresenceRatio(
-        sorting=sorting, 
-        threshold=threshold, 
-        threshold_sign=threshold_sign, 
+        sorting=sorting,
+        threshold=threshold,
+        threshold_sign=threshold_sign,
         sampling_frequency=sampling_frequency,
         metric_calculator=metric_calculator
     )

--- a/spiketoolkit/curation/threshold_snr.py
+++ b/spiketoolkit/curation/threshold_snr.py
@@ -3,33 +3,42 @@ import spiketoolkit as st
 
 
 class ThresholdSNR(ThresholdCurator):
-
     curator_name = 'ThresholdMinSNR'
     installed = True  # check at class level if installed or not
     curator_gui_params = [
-        {'name': 'threshold', 'type': 'float', 'value':5.0, 'default':5.0, 'title': "The threshold for the given metric."},
-        {'name': 'threshold_sign', 'type': 'str', 'value':'less', 'default':'less', 'title': "If 'less', will threshold any metric less than the given threshold. If 'greater', will threshold any metric greater than the given threshold."},
-        {'name': 'snr_mode', 'type': 'str', 'value':'mad', 'default':'mad', 'title': "Mode to compute noise SNR ('mad' | 'std' - default 'mad')"},
-        {'name': 'snr_noise_duration', 'type': 'float', 'value':10.0, 'default':10.0, 'title': "Number of seconds to compute noise level from (default 10.0)."},
-        {'name': 'max_snr_spikes_per_unit', 'type': 'float', 'value':1000, 'default':1000, 'title': "Maximum number of waveforms to compute templates from (default 1000)."},
-        {'name': 'seed', 'type': 'int', 'value':0, 'default':0, 'title': "Random seed for computing SNR."},
-   ]
-    installation_mesg = "" # err
+        {'name': 'threshold', 'type': 'float', 'value': 5.0, 'default': 5.0,
+         'title': "The threshold for the given metric."},
+        {'name': 'threshold_sign', 'type': 'str', 'value': 'less', 'default': 'less',
+         'title': "If 'less', will threshold any metric less than the given threshold. "
+                  "If 'greater', will threshold any metric greater than the given threshold."},
+        {'name': 'snr_mode', 'type': 'str', 'value': 'mad', 'default': 'mad',
+         'title': "Mode to compute noise SNR ('mad' | 'std' - default 'mad')"},
+        {'name': 'snr_noise_duration', 'type': 'float', 'value': 10.0, 'default': 10.0,
+         'title': "Number of seconds to compute noise level from (default 10.0)."},
+        {'name': 'max_snr_spikes_per_unit', 'type': 'float', 'value': 1000, 'default': 1000,
+         'title': "Maximum number of waveforms to compute templates from (default 1000)."},
+        {'name': 'seed', 'type': 'int', 'value': 0, 'default': 0, 'title': "Random seed for computing SNR."},
+    ]
+    installation_mesg = ""  # err
 
-    def __init__(self, sorting, recording, threshold=5.0, threshold_sign='less', snr_mode='mad', snr_noise_duration=10.0, \
-                 max_snr_spikes_per_unit=1000, recompute_waveform_info=True, save_features_props=False, metric_calculator=None, seed=0):
+    def __init__(self, sorting, recording, threshold=5.0, threshold_sign='less', snr_mode='mad',
+                 snr_noise_duration=10.0, max_snr_spikes_per_unit=1000, recompute_info=True,
+                 save_features_props=False, metric_calculator=None, seed=0):
         metric_name = 'snr'
         if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(), \
+            self._metric_calculator = st.validation.MetricCalculator(sorting,
+                                                                     sampling_frequency=recording.get_sampling_frequency(),
                                                                      unit_ids=None, epoch_tuples=None, epoch_names=None)
             self._metric_calculator.set_recording(recording)
-            self._metric_calculator.compute_snrs(snr_mode, snr_noise_duration, max_snr_spikes_per_unit, recompute_waveform_info=recompute_waveform_info, \
+            self._metric_calculator.compute_snrs(snr_mode, snr_noise_duration, max_snr_spikes_per_unit,
+                                                 recompute_info=recompute_info,
                                                  save_features_props=save_features_props, seed=seed)
         else:
             self._metric_calculator = metric_calculator
             if metric_name not in self._metric_calculator.get_metrics_dict().keys():
                 self._metric_calculator.set_recording(recording)
-                self._metric_calculator.compute_snrs(snr_mode, snr_noise_duration, max_snr_spikes_per_unit, recompute_waveform_info=recompute_waveform_info, \
+                self._metric_calculator.compute_snrs(snr_mode, snr_noise_duration, max_snr_spikes_per_unit,
+                                                     recompute_info=recompute_info,
                                                      save_features_props=save_features_props, seed=seed)
         snrs_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0]
 
@@ -37,8 +46,9 @@ class ThresholdSNR(ThresholdCurator):
         self.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
 
 
-def threshold_snr(sorting, recording, threshold=5.0, threshold_sign='less', snr_mode='mad', snr_noise_duration=10.0, \
-                  max_snr_spikes_per_unit=1000, recompute_waveform_info=True, save_features_props=False, metric_calculator=None, seed=0):
+def threshold_snr(sorting, recording, threshold=5.0, threshold_sign='less', snr_mode='mad', snr_noise_duration=10.0,
+                  max_snr_spikes_per_unit=1000, recompute_info=True, save_features_props=False,
+                  metric_calculator=None, seed=0):
     '''
     Excludes units based on snr.
 
@@ -61,7 +71,7 @@ def threshold_snr(sorting, recording, threshold=5.0, threshold_sign='less', snr_
         Number of seconds to compute noise level from (default 10.0)
     max_snr_spikes_per_unit: int
         Maximum number of spikes to compute templates from (default 1000)
-    recompute_waveform_info: bool
+    recompute_info: bool
         If True, waveforms are recomputed
     save_features_props: bool
         If True, waveforms and templates are saved as sorting features/properties
@@ -83,7 +93,7 @@ def threshold_snr(sorting, recording, threshold=5.0, threshold_sign='less', snr_
         snr_mode=snr_mode,
         snr_noise_duration=snr_noise_duration,
         max_snr_spikes_per_unit=max_snr_spikes_per_unit,
-        recompute_waveform_info=recompute_waveform_info,
+        recompute_info=recompute_info,
         save_features_props=save_features_props,
         metric_calculator=metric_calculator,
         seed=seed

--- a/spiketoolkit/curation/thresholdcurator.py
+++ b/spiketoolkit/curation/thresholdcurator.py
@@ -1,6 +1,7 @@
 from .curationsortingextractor import CurationSortingExtractor
 import spiketoolkit as st
 
+
 class ThresholdCurator(CurationSortingExtractor):
     def __init__(self, sorting, metrics_epoch):
         '''
@@ -15,8 +16,7 @@ class ThresholdCurator(CurationSortingExtractor):
         '''
         CurationSortingExtractor.__init__(self, parent_sorting=sorting)
         self._metrics_epoch = metrics_epoch
-        
-    
+
     def threshold_sorting(self, threshold, threshold_sign):
         '''
         Parameters

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -715,7 +715,7 @@ def set_unit_properties_by_max_channel_properties(recording, sorting, property, 
 
 def export_to_phy(recording, sorting, output_folder, nPC=3, electrode_dimensions=None,
                   grouping_property=None, ms_before=1., ms_after=2., dtype=None, amp_method='absolute', amp_peak='both',
-                  amp_frames_before=3, amp_frames_after=3, max_spikes_per_unit=np.inf, max_spikes_for_pca=np.inf,
+                  amp_frames_before=3, amp_frames_after=3, max_spikes_for_pca=1e5,
                   recompute_waveform_info=True, save_features_props=False, write_waveforms=False, verbose=False,
                   seed=0):
     '''
@@ -751,8 +751,6 @@ def export_to_phy(recording, sorting, output_folder, nPC=3, electrode_dimensions
         Frames before peak to compute amplitude
     amp_frames_after: int
         Frames after peak to compute amplitude
-    max_spikes_per_unit: int
-        The maximum number of spikes to extract per unit.
     max_spikes_for_pca: int
         The maximum number of waveforms to use to compute PCA (default is np.inf)
     recompute_waveform_info: bool
@@ -768,6 +766,8 @@ def export_to_phy(recording, sorting, output_folder, nPC=3, electrode_dimensions
     '''
     if not isinstance(recording, se.RecordingExtractor) or not isinstance(sorting, se.SortingExtractor):
         raise AttributeError()
+
+    max_spikes_per_unit = np.inf
 
     _empty_flag = False
     for unit_id in sorting.get_unit_ids():
@@ -1015,8 +1015,8 @@ def _get_phy_data(recording, sorting, nPC, electrode_dimensions, grouping_proper
         for unit_id in sorting.get_unit_ids():
             waveforms.append(sorting.get_unit_spike_features(unit_id, 'waveforms'))
 
-    spike_times, spike_clusters, spike_clusters_amps, spike_clusters_pcs, amplitudes, \
-    channel_map, pc_features, pc_feature_ind \
+    spike_times, spike_times_amps, spike_times_pca, spike_clusters, spike_clusters_amps, spike_clusters_pca, \
+    amplitudes, channel_map, pc_features, pc_feature_ind \
         = _get_quality_metric_data(recording, sorting, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
                                    dtype=dtype, amp_method=amp_method, amp_peak=amp_peak,
                                    amp_frames_before=amp_frames_before,

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -713,7 +713,7 @@ def set_unit_properties_by_max_channel_properties(recording, sorting, property, 
             sorting.set_unit_property(unit_id, property, recording.get_channel_property(max_chan, property))
 
 
-def export_to_phy(recording, sorting, output_folder, nPC=3, electrode_dimensions=None,
+def export_to_phy(recording, sorting, output_folder, n_comp=3, electrode_dimensions=None,
                   grouping_property=None, ms_before=1., ms_after=2., dtype=None, amp_method='absolute', amp_peak='both',
                   amp_frames_before=3, amp_frames_after=3, max_spikes_for_pca=1e5,
                   recompute_info=True, save_features_props=False, write_waveforms=False, verbose=False,
@@ -729,8 +729,8 @@ def export_to_phy(recording, sorting, output_folder, nPC=3, electrode_dimensions
         The sorting extractor
     output_folder: str
         The output folder where the phy template-gui files are saved
-    nPC: int
-        nPCFeatures in template-gui format
+    n_comp: int
+        n_compFeatures in template-gui format
     electrode_dimensions: list
         If electrode locations are 3D, it indicates the 2D dimensions to use as channel location
     grouping_property: str
@@ -802,7 +802,7 @@ def export_to_phy(recording, sorting, output_folder, nPC=3, electrode_dimensions
 
     spike_times, spike_clusters, amplitudes, channel_map, pc_features, pc_feature_ind, waveforms, \
     spike_templates, templates, templates_ind, similar_templates, channel_map_si, channel_groups, \
-    positions = _get_phy_data(recording, sorting, nPC, electrode_dimensions, grouping_property, ms_before,
+    positions = _get_phy_data(recording, sorting, n_comp, electrode_dimensions, grouping_property, ms_before,
                               ms_after, dtype, amp_method, amp_peak, amp_frames_before, amp_frames_after,
                               max_spikes_per_unit, max_spikes_for_pca, recompute_info, save_features_props,
                               verbose, seed)
@@ -955,12 +955,12 @@ def _get_amp_metric_data(recording, sorting, amp_method, amp_peak,
     return spike_times, spike_clusters, amplitudes
 
 
-def _get_pca_metric_data(recording, sorting, nPC, ms_before, ms_after, dtype, max_spikes_per_unit, max_spikes_for_pca,
+def _get_pca_metric_data(recording, sorting, n_comp, ms_before, ms_after, dtype, max_spikes_per_unit, max_spikes_for_pca,
                          recompute_info, save_features_props, verbose, seed):
     if recompute_info:
         sorting.clear_units_spike_features(feature_name='waveforms')
 
-    pc_scores, pca_idxs = compute_unit_pca_scores(recording, sorting, n_comp=nPC, by_electrode=True,
+    pc_scores, pca_idxs = compute_unit_pca_scores(recording, sorting, n_comp=n_comp, by_electrode=True,
                                                   max_spikes_per_unit=max_spikes_per_unit, ms_before=ms_before,
                                                   ms_after=ms_after, dtype=dtype, save_as_features=save_features_props,
                                                   max_spikes_for_pca=max_spikes_for_pca, verbose=verbose, seed=seed,
@@ -1000,14 +1000,14 @@ def _get_pca_metric_data(recording, sorting, nPC, ms_before, ms_after, dtype, ma
     return spike_times, spike_clusters, pc_features, pc_feature_ind
 
 
-def _get_quality_metric_data(recording, sorting, nPC, ms_before, ms_after, dtype, amp_method, amp_peak,
+def _get_quality_metric_data(recording, sorting, n_comp, ms_before, ms_after, dtype, amp_method, amp_peak,
                              amp_frames_before, amp_frames_after, max_spikes_per_unit, max_spikes_for_pca,
                              recompute_info, save_features_props, verbose, seed):
     if recompute_info:
         sorting.clear_units_spike_features(feature_name='waveforms')
         sorting.clear_units_spike_features(feature_name='amplitudes')
 
-    pc_scores, pca_idxs = compute_unit_pca_scores(recording, sorting, n_comp=nPC, by_electrode=True,
+    pc_scores, pca_idxs = compute_unit_pca_scores(recording, sorting, n_comp=n_comp, by_electrode=True,
                                                   max_spikes_per_unit=max_spikes_per_unit, ms_before=ms_before,
                                                   ms_after=ms_after, dtype=dtype, save_as_features=save_features_props,
                                                   max_spikes_for_pca=max_spikes_for_pca, verbose=verbose, seed=seed,
@@ -1081,7 +1081,7 @@ def _get_quality_metric_data(recording, sorting, nPC, ms_before, ms_after, dtype
            amplitudes, pc_features, pc_feature_ind
 
 
-def _get_phy_data(recording, sorting, nPC, electrode_dimensions, grouping_property,
+def _get_phy_data(recording, sorting, n_comp, electrode_dimensions, grouping_property,
                   ms_before, ms_after, dtype, amp_method, amp_peak, amp_frames_before,
                   amp_frames_after, max_spikes_per_unit, max_spikes_for_pca,
                   recompute_info, save_features_props, verbose, seed):
@@ -1117,7 +1117,7 @@ def _get_phy_data(recording, sorting, nPC, electrode_dimensions, grouping_proper
 
     spike_times, spike_times_amps, spike_times_pca, spike_clusters, spike_clusters_amps, spike_clusters_pca, \
     amplitudes, pc_features, pc_feature_ind \
-        = _get_quality_metric_data(recording, sorting, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+        = _get_quality_metric_data(recording, sorting, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                    dtype=dtype, amp_method=amp_method, amp_peak=amp_peak,
                                    amp_frames_before=amp_frames_before,
                                    amp_frames_after=amp_frames_after, max_spikes_per_unit=max_spikes_per_unit,

--- a/spiketoolkit/tests/test_curation.py
+++ b/spiketoolkit/tests/test_curation.py
@@ -1,8 +1,30 @@
 import spikeextractors as se
-from numpy.testing import assert_array_equal
-from spiketoolkit.curation import threshold_snr, threshold_firing_rate, threshold_isi_violations, threshold_num_spikes, \
-    threshold_presence_ratio, CurationSortingExtractor
+import numpy as np
+from spiketoolkit.curation import threshold_snr, threshold_firing_rate, threshold_isi_violations, \
+    threshold_num_spikes, threshold_presence_ratio
+from spiketoolkit.validation import compute_snrs, compute_firing_rates
+
+
+def test_thresh_snr():
+    rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4)
+    snr_thresh = 4
+
+    sort_snr = threshold_snr(sort, rec, snr_thresh, 'less')
+    new_snr = compute_snrs(sort_snr, rec)
+
+    assert np.all(new_snr > snr_thresh)
 
 
 def test_thresh_fr():
-    pass
+    rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4)
+    fr_thresh = 2
+
+    sort_fr = threshold_firing_rate(sort, fr_thresh, 'less')
+    new_fr = compute_firing_rates(sort_fr)
+
+    assert np.all(new_fr > fr_thresh)
+
+
+if __name__ == '__main__':
+    test_thresh_snr()
+    test_thresh_fr()

--- a/spiketoolkit/tests/test_validation.py
+++ b/spiketoolkit/tests/test_validation.py
@@ -6,9 +6,43 @@ from spiketoolkit.validation import compute_isolation_distances, compute_isi_vio
     MetricCalculator
 
 
-def test_snrs():
-    pass
-
-
 def test_calculator():
-    pass
+    rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4)
+    mc = MetricCalculator(sort, rec)
+
+    _ = mc.compute_metrics()
+    metric_dict = mc.get_metrics_dict()
+    assert 'firing_rate' in metric_dict.keys()
+    assert 'num_spikes' in metric_dict.keys()
+    assert 'isi_viol' in metric_dict.keys()
+    assert 'presence_ratio' in metric_dict.keys()
+    assert 'amplitude_cutoff' in metric_dict.keys()
+    assert 'max_drift' in metric_dict.keys()
+    assert 'cumulative_drift' in metric_dict.keys()
+    assert 'silhouette_score' in metric_dict.keys()
+    assert 'isolation_distance' in metric_dict.keys()
+    assert 'l_ratio' in metric_dict.keys()
+    assert 'd_prime' in metric_dict.keys()
+    assert 'nn_hit_rate' in metric_dict.keys()
+    assert 'nn_miss_rate' in metric_dict.keys()
+    assert 'snr' in metric_dict.keys()
+
+
+def test_functions():
+    rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4)
+
+    firing_rates = compute_firing_rates(sort)
+    num_spikes = compute_num_spikes(sort)
+    isi = compute_isi_violations(sort)
+    presence = compute_presence_ratios(sort)
+
+    amp_cutoff = compute_amplitude_cutoffs(sort, rec)
+
+    max_drift, cum_drift = compute_drift_metrics(sort, rec)
+    silh = compute_silhouette_scores(sort, rec)
+    iso = compute_isolation_distances(sort, rec)
+    l_ratio = compute_l_ratios(sort, rec)
+    dprime = compute_d_primes(sort, rec)
+    nn_hit, nn_miss = compute_nn_metrics(sort, rec)
+
+    snr = compute_snrs(sort, rec)

--- a/spiketoolkit/validation/__init__.py
+++ b/spiketoolkit/validation/__init__.py
@@ -1,5 +1,6 @@
-from .validation_tools import get_firing_times_ids, get_quality_metric_data
-from .quality_metrics import compute_num_spikes, compute_firing_rates, compute_presence_ratios, compute_isi_violations, \
-                             compute_amplitude_cutoffs, compute_snrs, compute_drift_metrics, compute_silhouette_scores, \
-                             compute_isolation_distances, compute_l_ratios, compute_d_primes, compute_nn_metrics, compute_metrics
+from .validation_tools import get_all_metric_data, get_pca_metric_data, get_amplitude_metric_data, \
+    get_spike_times_metrics_data
+from .quality_metrics import compute_num_spikes, compute_firing_rates, compute_presence_ratios, \
+    compute_isi_violations, compute_amplitude_cutoffs, compute_snrs, compute_drift_metrics, compute_silhouette_scores, \
+    compute_isolation_distances, compute_l_ratios, compute_d_primes, compute_nn_metrics, compute_metrics
 from .metric_calculator import MetricCalculator

--- a/spiketoolkit/validation/metric_calculator.py
+++ b/spiketoolkit/validation/metric_calculator.py
@@ -138,7 +138,7 @@ class MetricCalculator:
         self._spike_clusters_amps = spike_clusters
         self._spike_times_amps = spike_times
 
-    def compute_pca_scores(self, recording=None, nPC=3, ms_before=1., ms_after=2., dtype=None,
+    def compute_pca_scores(self, recording=None, n_comp=3, ms_before=1., ms_after=2., dtype=None,
                            max_spikes_per_unit=300, recompute_info=True,
                            max_spikes_for_pca=1e5, save_features_props=False, seed=0):
         '''
@@ -148,8 +148,8 @@ class MetricCalculator:
         ----------
         recording: RecordingExtractor
             The recording extractor
-        nPC: int
-            nPCFeatures in template-gui format
+        n_comp: int
+            n_compFeatures in template-gui format
         ms_before: float
             Time period in ms to cut waveforms before the spike events
         ms_after: float
@@ -175,7 +175,7 @@ class MetricCalculator:
             self.set_recording(recording)
 
         spike_times, spike_clusters, pc_features, pc_feature_ind = get_pca_metric_data(self._recording, self._sorting,
-                                                                                       nPC=nPC,
+                                                                                       n_comp=n_comp,
                                                                                        ms_before=ms_before,
                                                                                        ms_after=ms_after, dtype=dtype,
                                                                                        max_spikes_per_unit=
@@ -192,7 +192,7 @@ class MetricCalculator:
         self._spike_times_pca = spike_times
         self._pc_feature_ind = pc_feature_ind
 
-    def compute_all_metric_data(self, recording=None, nPC=3, ms_before=1., ms_after=2., dtype=None,
+    def compute_all_metric_data(self, recording=None, n_comp=3, ms_before=1., ms_after=2., dtype=None,
                                 max_spikes_per_unit=300, amp_method='absolute', amp_peak='both',
                                 amp_frames_before=3, amp_frames_after=3, recompute_info=True,
                                 max_spikes_for_pca=1e5, save_features_props=False, seed=0):
@@ -203,8 +203,8 @@ class MetricCalculator:
         ----------
         recording: RecordingExtractor
             The recording extractor
-        nPC: int
-            nPCFeatures in template-gui format
+        n_comp: int
+            n_compFeatures in template-gui format
         ms_before: float
             Time period in ms to cut waveforms before the spike events
         ms_after: float
@@ -239,7 +239,7 @@ class MetricCalculator:
             self.set_recording(recording)
         spike_times, spike_times_amps, spike_times_pca, spike_clusters, spike_clusters_amps, spike_clusters_pca, \
         amplitudes, pc_features, pc_feature_ind = get_all_metric_data(
-            self._recording, self._sorting, nPC=nPC, ms_before=ms_before,
+            self._recording, self._sorting, n_comp=n_comp, ms_before=ms_before,
             ms_after=ms_after, dtype=dtype, amp_method=amp_method,
             amp_peak=amp_peak, amp_frames_before=amp_frames_before,
             amp_frames_after=amp_frames_after, max_spikes_per_unit=max_spikes_per_unit,

--- a/spiketoolkit/validation/quality_metrics.py
+++ b/spiketoolkit/validation/quality_metrics.py
@@ -304,7 +304,7 @@ def compute_snrs(sorting, recording, snr_mode='mad', snr_noise_duration=10.0, ma
 
 
 def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift_metrics_min_spikes_per_interval=10,
-                          nPC=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=300, recompute_info=True,
+                          n_comp=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=300, recompute_info=True,
                           max_spikes_for_pca=1e5, save_features_props=False, unit_ids=None, epoch_tuples=None,
                           epoch_names=None, save_as_property=True, seed=0):
     '''
@@ -320,8 +320,8 @@ def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift
         Time period for evaluating drift.
     drift_metrics_min_spikes_per_interval: int
         Minimum number of spikes for evaluating drift metrics per interval.
-    nPC: int
-        nPCFeatures in template-gui format
+    n_comp: int
+        n_compFeatures in template-gui format
     ms_before: float
         Time period in ms to cut waveforms before the spike events
     ms_after: float
@@ -360,7 +360,7 @@ def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+    metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
                                          recompute_info=recompute_info,
@@ -381,7 +381,7 @@ def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift
     return max_drifts_epochs, cumulative_drifts_epochs
 
 
-def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=10000, nPC=3, ms_before=1., ms_after=2.,
+def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=10000, n_comp=3, ms_before=1., ms_after=2.,
                               dtype=None, max_spikes_per_unit=300, recompute_info=True,
                               max_spikes_for_pca=1e5, save_features_props=False, unit_ids=None, epoch_tuples=None,
                               epoch_names=None, save_as_property=True, seed=0):
@@ -396,8 +396,8 @@ def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=1000
         The given recording extractor from which to extract amplitudes.
     max_spikes_for_silhouette: int
         Max spikes to be used for silhouette metric
-    nPC: int
-        nPCFeatures in template-gui format
+    n_comp: int
+        n_compFeatures in template-gui format
     ms_before: float
         Time period in ms to cut waveforms before the spike events
     ms_after: float
@@ -434,7 +434,7 @@ def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=1000
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+    metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
                                          recompute_info=recompute_info,
@@ -453,7 +453,7 @@ def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=1000
     return silhouette_scores_epochs
 
 
-def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, nPC=3,
+def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, n_comp=3,
                                 ms_before=1., ms_after=2.,
                                 dtype=None, max_spikes_per_unit=300, recompute_info=True, max_spikes_for_pca=1e5,
                                 save_features_props=False,
@@ -471,8 +471,8 @@ def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, 
         The number of channels to be used for the PC extraction and comparison
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-    nPC: int
-        nPCFeatures in template-gui format
+    n_comp: int
+        n_compFeatures in template-gui format
     ms_before: float
         Time period in ms to cut waveforms before the spike events
     ms_after: float
@@ -509,7 +509,7 @@ def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, 
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+    metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
                                          recompute_info=recompute_info,
@@ -529,7 +529,7 @@ def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, 
     return isolation_distances_epochs
 
 
-def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, nPC=3, ms_before=1.,
+def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, n_comp=3, ms_before=1.,
                      ms_after=2., dtype=None, max_spikes_per_unit=300, recompute_info=True,
                      max_spikes_for_pca=1e5, save_features_props=False, unit_ids=None, epoch_tuples=None,
                      epoch_names=None, save_as_property=True, seed=0):
@@ -546,8 +546,8 @@ def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_
         The number of channels to be used for the PC extraction and comparison
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-    nPC: int
-        nPCFeatures in template-gui format
+    n_comp: int
+        n_compFeatures in template-gui format
     ms_before: float
         Time period in ms to cut waveforms before the spike events
     ms_after: float
@@ -584,7 +584,7 @@ def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+    metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
                                          recompute_info=recompute_info,
@@ -603,7 +603,7 @@ def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_
     return l_ratios_epochs
 
 
-def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, nPC=3, ms_before=1.,
+def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, n_comp=3, ms_before=1.,
                      ms_after=2., dtype=None, max_spikes_per_unit=300, recompute_info=True,
                      max_spikes_for_pca=1e5,
                      save_features_props=False, unit_ids=None, epoch_tuples=None, epoch_names=None,
@@ -621,8 +621,8 @@ def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_
         The number of channels to be used for the PC extraction and comparison
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-    nPC: int
-        nPCFeatures in template-gui format
+    n_comp: int
+        n_compFeatures in template-gui format
     ms_before: float
         Time period in ms to cut waveforms before the spike events
     ms_after: float
@@ -659,7 +659,7 @@ def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+    metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
                                          recompute_info=recompute_info,
@@ -680,7 +680,7 @@ def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_
 
 def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500,
                        max_spikes_for_nn=10000,
-                       n_neighbors=4, nPC=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=300,
+                       n_neighbors=4, n_comp=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=300,
                        recompute_info=True, max_spikes_for_pca=1e5, save_features_props=False,
                        unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
     '''
@@ -700,8 +700,8 @@ def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spike
         Max spikes to be used for nearest-neighbors calculation.
     n_neighbors: int
         Number of neighbors to compare.
-    nPC: int
-        nPCFeatures in template-gui format
+    n_comp: int
+        n_compFeatures in template-gui format
     ms_before: float
         Time period in ms to cut waveforms before the spike events
     ms_after: float
@@ -740,7 +740,7 @@ def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spike
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+    metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
                                          recompute_info=recompute_info,
@@ -766,7 +766,7 @@ def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_thresh
                     snr_mode='mad', snr_noise_duration=10.0, max_spikes_per_unit_for_snr=1000,
                     drift_metrics_interval_s=51, drift_metrics_min_spikes_per_interval=10,
                     max_spikes_for_silhouette=10000, num_channels_to_compare=13, max_spikes_per_cluster=500,
-                    max_spikes_for_nn=10000, n_neighbors=4, nPC=3, ms_before=1., ms_after=2., dtype=None,
+                    max_spikes_for_nn=10000, n_neighbors=4, n_comp=3, ms_before=1., ms_after=2., dtype=None,
                     max_spikes_per_unit=300,  amp_method='absolute', amp_peak='both', amp_frames_before=3, 
                     amp_frames_after=3, recompute_info=True,  max_spikes_for_pca=1e5, save_features_props=False, 
                     metric_names=None, unit_ids=None, epoch_tuples=None, epoch_names=None, return_dataframe=False, 
@@ -823,8 +823,8 @@ def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_thresh
         The maximum number of spikes to use to compute PCA (default is np.inf)
     save_features_props: bool
         If True, save all features and properties in the sorting extractor.
-    nPC: int
-        nPCFeatures in template-gui format
+    n_comp: int
+        n_compFeatures in template-gui format
     ms_before: float
         Time period in ms to cut waveforms before the spike events
     ms_after: float
@@ -885,7 +885,7 @@ def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_thresh
                              "silhouette_score isolation_distance, l_ratio, d_prime, nn_hit_rate, amplitude_cutoff, "
                              "or nn_miss_rate.")
         else:
-            metric_calculator.compute_all_metric_data(recording=recording, nPC=nPC, ms_before=ms_before,
+            metric_calculator.compute_all_metric_data(recording=recording, n_comp=n_comp, ms_before=ms_before,
                                                       ms_after=ms_after, dtype=dtype,
                                                       max_spikes_per_unit=max_spikes_per_unit, amp_method=amp_method,
                                                       amp_peak=amp_peak,

--- a/spiketoolkit/validation/quality_metrics.py
+++ b/spiketoolkit/validation/quality_metrics.py
@@ -1,6 +1,4 @@
-from .metric_calculator import MetricCalculator
 import spiketoolkit as st
-import numpy as np
 
 
 def compute_num_spikes(sorting, sampling_frequency=None, unit_ids=None, epoch_tuples=None, epoch_names=None,
@@ -246,7 +244,7 @@ def compute_amplitude_cutoffs(sorting, recording, amp_method='absolute', amp_pea
 
 
 def compute_snrs(sorting, recording, snr_mode='mad', snr_noise_duration=10.0, max_spikes_per_unit_for_snr=1000,
-                 recompute_waveform_info=True, save_features_props=False, unit_ids=None, epoch_tuples=None,
+                 recompute_info=True, save_features_props=False, unit_ids=None, epoch_tuples=None,
                  epoch_names=None, save_as_property=True, seed=0):
     '''
     Computes and stores snrs for the sorted units.
@@ -265,7 +263,7 @@ def compute_snrs(sorting, recording, snr_mode='mad', snr_noise_duration=10.0, ma
         Maximum number of spikes to compute templates from (default 1000)
     unit_ids: list
         List of unit ids to compute metric for. If not specified, all units are used
-    recompute_waveform_info: bool
+    recompute_info: bool
         If True, waveforms are recomputed
     save_features_props: bool
         If True, waveforms and templates are saved as properties and features of the sorting extractor
@@ -293,7 +291,7 @@ def compute_snrs(sorting, recording, snr_mode='mad', snr_noise_duration=10.0, ma
     metric_calculator.set_recording(recording)
     snrs_epochs = metric_calculator.compute_snrs(snr_mode=snr_mode, snr_noise_duration=snr_noise_duration,
                                                  max_spikes_per_unit_for_snr=max_spikes_per_unit_for_snr,
-                                                 recompute_waveform_info=recompute_waveform_info,
+                                                 recompute_info=recompute_info,
                                                  save_features_props=save_features_props, seed=seed)
 
     if save_as_property:
@@ -306,9 +304,8 @@ def compute_snrs(sorting, recording, snr_mode='mad', snr_noise_duration=10.0, ma
 
 
 def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift_metrics_min_spikes_per_interval=10,
-                          nPC=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=np.inf, amp_method='absolute',
-                          amp_peak='both', amp_frames_before=3, amp_frames_after=3, recompute_waveform_info=True,
-                          max_spikes_for_pca=np.inf, save_features_props=False, unit_ids=None, epoch_tuples=None,
+                          nPC=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=300, recompute_info=True,
+                          max_spikes_for_pca=1e5, save_features_props=False, unit_ids=None, epoch_tuples=None,
                           epoch_names=None, save_as_property=True, seed=0):
     '''
     Computes and returns the drift metrics for the sorted dataset.
@@ -333,16 +330,7 @@ def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift
         The numpy dtype of the waveforms
     max_spikes_per_unit: int
         The maximum number of spikes to extract (default is np.inf)
-    amp_method: str
-        If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
-        If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
-    amp_peak: str
-        If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-    amp_frames_before: int
-        Frames before peak to compute amplitude
-    amp_frames_after: float
-        Frames after peak to compute amplitude
-    recompute_waveform_info: bool
+    recompute_info: bool
         If True, will always re-extract waveforms.
     max_spikes_for_pca: int
         The maximum number of spikes to use to compute PCA (default is np.inf)
@@ -372,14 +360,12 @@ def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_all_metric_data(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
-                                              dtype=dtype,
-                                              max_spikes_per_unit=max_spikes_per_unit, amp_method=amp_method,
-                                              amp_peak=amp_peak,
-                                              amp_frames_before=amp_frames_before, amp_frames_after=amp_frames_after,
-                                              recompute_waveform_info=recompute_waveform_info,
-                                              max_spikes_for_pca=max_spikes_for_pca,
-                                              save_features_props=save_features_props, seed=seed)
+    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+                                         dtype=dtype,
+                                         max_spikes_per_unit=max_spikes_per_unit,
+                                         recompute_info=recompute_info,
+                                         max_spikes_for_pca=max_spikes_for_pca,
+                                         save_features_props=save_features_props, seed=seed)
     max_drifts_epochs, cumulative_drifts_epochs = metric_calculator.compute_drift_metrics(
         drift_metrics_interval_s=drift_metrics_interval_s,
         drift_metrics_min_spikes_per_interval=drift_metrics_min_spikes_per_interval)
@@ -396,11 +382,9 @@ def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift
 
 
 def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=10000, nPC=3, ms_before=1., ms_after=2.,
-                              dtype=None, max_spikes_per_unit=np.inf, amp_method='absolute', amp_peak='both',
-                              amp_frames_before=3,
-                              amp_frames_after=3, recompute_waveform_info=True, max_spikes_for_pca=np.inf,
-                              save_features_props=False,
-                              unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
+                              dtype=None, max_spikes_per_unit=300, recompute_info=True,
+                              max_spikes_for_pca=1e5, save_features_props=False, unit_ids=None, epoch_tuples=None,
+                              epoch_names=None, save_as_property=True, seed=0):
     '''
     Computes and returns the silhouette scores in the sorted dataset.
 
@@ -422,16 +406,7 @@ def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=1000
         The numpy dtype of the waveforms
     max_spikes_per_unit: int
         The maximum number of spikes to extract (default is np.inf)
-    amp_method: str
-        If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
-        If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
-    amp_peak: str
-        If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-    amp_frames_before: int
-        Frames before peak to compute amplitude
-    amp_frames_after: float
-        Frames after peak to compute amplitude
-    recompute_waveform_info: bool
+    recompute_info: bool
         If True, will always re-extract waveforms.
     max_spikes_for_pca: int
         The maximum number of spikes to use to compute PCA (default is np.inf)
@@ -459,14 +434,12 @@ def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=1000
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_all_metric_data(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
-                                              dtype=dtype,
-                                              max_spikes_per_unit=max_spikes_per_unit, amp_method=amp_method,
-                                              amp_peak=amp_peak,
-                                              amp_frames_before=amp_frames_before, amp_frames_after=amp_frames_after,
-                                              recompute_waveform_info=recompute_waveform_info,
-                                              max_spikes_for_pca=max_spikes_for_pca,
-                                              save_features_props=save_features_props, seed=seed)
+    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+                                         dtype=dtype,
+                                         max_spikes_per_unit=max_spikes_per_unit,
+                                         recompute_info=recompute_info,
+                                         max_spikes_for_pca=max_spikes_for_pca,
+                                         save_features_props=save_features_props, seed=seed)
     silhouette_scores_epochs = metric_calculator.compute_silhouette_scores(
         max_spikes_for_silhouette=max_spikes_for_silhouette, seed=seed)
 
@@ -482,9 +455,7 @@ def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=1000
 
 def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, nPC=3,
                                 ms_before=1., ms_after=2.,
-                                dtype=None, max_spikes_per_unit=np.inf, amp_method='absolute', amp_peak='both',
-                                amp_frames_before=3,
-                                amp_frames_after=3, recompute_waveform_info=True, max_spikes_for_pca=np.inf,
+                                dtype=None, max_spikes_per_unit=300, recompute_info=True, max_spikes_for_pca=1e5,
                                 save_features_props=False,
                                 unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
     '''
@@ -510,16 +481,7 @@ def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, 
         The numpy dtype of the waveforms
     max_spikes_per_unit: int
         The maximum number of spikes to extract (default is np.inf)
-    amp_method: str
-        If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
-        If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
-    amp_peak: str
-        If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-    amp_frames_before: int
-        Frames before peak to compute amplitude
-    amp_frames_after: float
-        Frames after peak to compute amplitude
-    recompute_waveform_info: bool
+    recompute_info: bool
         If True, will always re-extract waveforms.
     max_spikes_for_pca: int
         The maximum number of spikes to use to compute PCA (default is np.inf)
@@ -547,14 +509,12 @@ def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, 
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_all_metric_data(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
-                                              dtype=dtype,
-                                              max_spikes_per_unit=max_spikes_per_unit, amp_method=amp_method,
-                                              amp_peak=amp_peak,
-                                              amp_frames_before=amp_frames_before, amp_frames_after=amp_frames_after,
-                                              recompute_waveform_info=recompute_waveform_info,
-                                              max_spikes_for_pca=max_spikes_for_pca,
-                                              save_features_props=save_features_props, seed=seed)
+    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+                                         dtype=dtype,
+                                         max_spikes_per_unit=max_spikes_per_unit,
+                                         recompute_info=recompute_info,
+                                         max_spikes_for_pca=max_spikes_for_pca,
+                                         save_features_props=save_features_props, seed=seed)
     isolation_distances_epochs = metric_calculator.compute_isolation_distances(
         num_channels_to_compare=num_channels_to_compare,
         max_spikes_per_cluster=max_spikes_per_cluster, seed=seed)
@@ -570,11 +530,9 @@ def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, 
 
 
 def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, nPC=3, ms_before=1.,
-                     ms_after=2.,
-                     dtype=None, max_spikes_per_unit=np.inf, amp_method='absolute', amp_peak='both', amp_frames_before=3,
-                     amp_frames_after=3, recompute_waveform_info=True, max_spikes_for_pca=np.inf,
-                     save_features_props=False,
-                     unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
+                     ms_after=2., dtype=None, max_spikes_per_unit=300, recompute_info=True,
+                     max_spikes_for_pca=1e5, save_features_props=False, unit_ids=None, epoch_tuples=None,
+                     epoch_names=None, save_as_property=True, seed=0):
     '''
     Computes and returns the mahalanobis metric, l-ratio, for the sorted dataset.
 
@@ -598,16 +556,7 @@ def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_
         The numpy dtype of the waveforms
     max_spikes_per_unit: int
         The maximum number of spikes to extract (default is np.inf)
-    amp_method: str
-        If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
-        If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
-    amp_peak: str
-        If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-    amp_frames_before: int
-        Frames before peak to compute amplitude
-    amp_frames_after: float
-        Frames after peak to compute amplitude
-    recompute_waveform_info: bool
+    recompute_info: bool
         If True, will always re-extract waveforms.
     max_spikes_for_pca: int
         The maximum number of spikes to use to compute PCA (default is np.inf)
@@ -635,14 +584,12 @@ def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_all_metric_data(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
-                                              dtype=dtype,
-                                              max_spikes_per_unit=max_spikes_per_unit, amp_method=amp_method,
-                                              amp_peak=amp_peak,
-                                              amp_frames_before=amp_frames_before, amp_frames_after=amp_frames_after,
-                                              recompute_waveform_info=recompute_waveform_info,
-                                              max_spikes_for_pca=max_spikes_for_pca,
-                                              save_features_props=save_features_props, seed=seed)
+    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+                                         dtype=dtype,
+                                         max_spikes_per_unit=max_spikes_per_unit,
+                                         recompute_info=recompute_info,
+                                         max_spikes_for_pca=max_spikes_for_pca,
+                                         save_features_props=save_features_props, seed=seed)
     l_ratios_epochs = metric_calculator.compute_l_ratios(num_channels_to_compare=num_channels_to_compare,
                                                          max_spikes_per_cluster=max_spikes_per_cluster, seed=seed)
 
@@ -657,11 +604,10 @@ def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_
 
 
 def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, nPC=3, ms_before=1.,
-                     ms_after=2.,
-                     dtype=None, max_spikes_per_unit=np.inf, amp_method='absolute', amp_peak='both', amp_frames_before=3,
-                     amp_frames_after=3, recompute_waveform_info=True, max_spikes_for_pca=np.inf,
-                     save_features_props=False,
-                     unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
+                     ms_after=2., dtype=None, max_spikes_per_unit=300, recompute_info=True,
+                     max_spikes_for_pca=1e5,
+                     save_features_props=False, unit_ids=None, epoch_tuples=None, epoch_names=None,
+                     save_as_property=True, seed=0):
     '''
     Computes and returns the lda-based metric, d-prime, for the sorted dataset.
 
@@ -685,16 +631,7 @@ def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_
         The numpy dtype of the waveforms
     max_spikes_per_unit: int
         The maximum number of spikes to extract (default is np.inf)
-    amp_method: str
-        If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
-        If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
-    amp_peak: str
-        If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-    amp_frames_before: int
-        Frames before peak to compute amplitude
-    amp_frames_after: float
-        Frames after peak to compute amplitude
-    recompute_waveform_info: bool
+    recompute_info: bool
         If True, will always re-extract waveforms.
     max_spikes_for_pca: int
         The maximum number of spikes to use to compute PCA (default is np.inf)
@@ -722,14 +659,12 @@ def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_all_metric_data(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
-                                              dtype=dtype,
-                                              max_spikes_per_unit=max_spikes_per_unit, amp_method=amp_method,
-                                              amp_peak=amp_peak,
-                                              amp_frames_before=amp_frames_before, amp_frames_after=amp_frames_after,
-                                              recompute_waveform_info=recompute_waveform_info,
-                                              max_spikes_for_pca=max_spikes_for_pca,
-                                              save_features_props=save_features_props, seed=seed)
+    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+                                         dtype=dtype,
+                                         max_spikes_per_unit=max_spikes_per_unit,
+                                         recompute_info=recompute_info,
+                                         max_spikes_for_pca=max_spikes_for_pca,
+                                         save_features_props=save_features_props, seed=seed)
     d_primes_epochs = metric_calculator.compute_d_primes(num_channels_to_compare=num_channels_to_compare,
                                                          max_spikes_per_cluster=max_spikes_per_cluster, seed=seed)
 
@@ -743,10 +678,10 @@ def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_
     return d_primes_epochs
 
 
-def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, max_spikes_for_nn=10000,
-                       n_neighbors=4, nPC=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=np.inf,
-                       amp_method='absolute', amp_peak='both', amp_frames_before=3, amp_frames_after=3,
-                       recompute_waveform_info=True, max_spikes_for_pca=np.inf, save_features_props=False,
+def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500,
+                       max_spikes_for_nn=10000,
+                       n_neighbors=4, nPC=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=300,
+                       recompute_info=True, max_spikes_for_pca=1e5, save_features_props=False,
                        unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
     '''
     Computes and returns the nearest neighbor metrics for the sorted dataset.
@@ -775,16 +710,7 @@ def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spike
         The numpy dtype of the waveforms
     max_spikes_per_unit: int
         The maximum number of spikes to extract (default is np.inf)
-    amp_method: str
-        If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
-        If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
-    amp_peak: str
-        If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-    amp_frames_before: int
-        Frames before peak to compute amplitude
-    amp_frames_after: float
-        Frames after peak to compute amplitude
-    recompute_waveform_info: bool
+    recompute_info: bool
         If True, will always re-extract waveforms.
     max_spikes_for_pca: int
         The maximum number of spikes to use to compute PCA (default is np.inf)
@@ -814,14 +740,12 @@ def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spike
     metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
-    metric_calculator.compute_all_metric_data(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
-                                              dtype=dtype,
-                                              max_spikes_per_unit=max_spikes_per_unit, amp_method=amp_method,
-                                              amp_peak=amp_peak,
-                                              amp_frames_before=amp_frames_before, amp_frames_after=amp_frames_after,
-                                              recompute_waveform_info=recompute_waveform_info,
-                                              max_spikes_for_pca=max_spikes_for_pca,
-                                              save_features_props=save_features_props, seed=seed)
+    metric_calculator.compute_pca_scores(recording=recording, nPC=nPC, ms_before=ms_before, ms_after=ms_after,
+                                         dtype=dtype,
+                                         max_spikes_per_unit=max_spikes_per_unit,
+                                         recompute_info=recompute_info,
+                                         max_spikes_for_pca=max_spikes_for_pca,
+                                         save_features_props=save_features_props, seed=seed)
     nn_hit_rates_epochs, nn_miss_rates_epochs = metric_calculator.compute_nn_metrics(
         num_channels_to_compare=num_channels_to_compare,
         max_spikes_per_cluster=max_spikes_per_cluster,
@@ -839,17 +763,14 @@ def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spike
 
 
 def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_threshold=0.0015, min_isi=0.000166,
-                    snr_mode='mad',
-                    snr_noise_duration=10.0, max_spikes_per_unit_for_snr=1000, drift_metrics_interval_s=51,
-                    drift_metrics_min_spikes_per_interval=10,
+                    snr_mode='mad', snr_noise_duration=10.0, max_spikes_per_unit_for_snr=1000,
+                    drift_metrics_interval_s=51, drift_metrics_min_spikes_per_interval=10,
                     max_spikes_for_silhouette=10000, num_channels_to_compare=13, max_spikes_per_cluster=500,
-                    max_spikes_for_nn=10000,
-                    n_neighbors=4, nPC=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=np.inf,
-                    amp_method='absolute',
-                    amp_peak='both', amp_frames_before=3, amp_frames_after=3, recompute_waveform_info=True,
-                    max_spikes_for_pca=np.inf,
-                    save_features_props=False, metric_names=None, unit_ids=None, epoch_tuples=None, epoch_names=None,
-                    return_dataframe=False, seed=0):
+                    max_spikes_for_nn=10000, n_neighbors=4, nPC=3, ms_before=1., ms_after=2., dtype=None,
+                    max_spikes_per_unit=300,  amp_method='absolute', amp_peak='both', amp_frames_before=3, 
+                    amp_frames_after=3, recompute_info=True,  max_spikes_for_pca=1e5, save_features_props=False, 
+                    metric_names=None, unit_ids=None, epoch_tuples=None, epoch_names=None, return_dataframe=False, 
+                    seed=0):
     '''
     Computes and returns all specified metrics for the sorted dataset.
 
@@ -885,8 +806,36 @@ def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_thresh
         Max spikes to be used for nearest-neighbors calculation.
     n_neighbors: int
         Number of neighbors to compare for  nearest-neighbors calculation.
+    max_spikes_per_unit: int
+        The maximum number of spikes to extract (default is np.inf)
+    amp_method: str
+        If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
+        If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
+    amp_peak: str
+        If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
+    amp_frames_before: int
+        Frames before peak to compute amplitude
+    amp_frames_after: float
+        Frames after peak to compute amplitude
+    recompute_info: bool
+        If True, will always re-extract waveforms.
+    max_spikes_for_pca: int
+        The maximum number of spikes to use to compute PCA (default is np.inf)
+    save_features_props: bool
+        If True, save all features and properties in the sorting extractor.
+    nPC: int
+        nPCFeatures in template-gui format
+    ms_before: float
+        Time period in ms to cut waveforms before the spike events
+    ms_after: float
+        Time period in ms to cut waveforms after the spike events
+    dtype: dtype
+        The numpy dtype of the waveforms
     metrics_names: list
-        The list of metric names to be computed.
+        The list of metric names to be computed. Available metrics are: 'firing_rate', 'num_spikes', 'isi_viol',
+            'presence_ratio', 'amplitude_cutoff', 'max_drift', 'cumulative_drift', 'silhouette_score',
+            'isolation_distance', 'l_ratio', 'd_prime', 'nn_hit_rate', 'nn_miss_rate', 'snr'. If None, all metrics are
+            computed.
     unit_ids: list
         List of unit ids to compute metric for. If not specified, all units are used
     epoch_tuples: list
@@ -930,10 +879,11 @@ def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_thresh
 
     if 'max_drift' in metric_names or 'cumulative_drift' in metric_names or 'silhouette_score' in metric_names \
             or 'isolation_distance' in metric_names or 'l_ratio' in metric_names or 'd_prime' in metric_names \
-            or 'nn_hit_rate' in metric_names or 'nn_miss_rate' in metric_names:
+            or 'nn_hit_rate' in metric_names or 'nn_miss_rate' in metric_names or 'amplitude_cutoff' in metric_names:
         if recording is None:
-            raise ValueError("The recording cannot be None when computing max_drift, cumulative_drift, silhouette_score \
-                              isolation_distance, l_ratio, d_prime, nn_hit_rate, or nn_miss_rate.")
+            raise ValueError("The recording cannot be None when computing max_drift, cumulative_drift, "
+                             "silhouette_score isolation_distance, l_ratio, d_prime, nn_hit_rate, amplitude_cutoff, "
+                             "or nn_miss_rate.")
         else:
             metric_calculator.compute_all_metric_data(recording=recording, nPC=nPC, ms_before=ms_before,
                                                       ms_after=ms_after, dtype=dtype,
@@ -941,18 +891,10 @@ def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_thresh
                                                       amp_peak=amp_peak,
                                                       amp_frames_before=amp_frames_before,
                                                       amp_frames_after=amp_frames_after,
-                                                      recompute_waveform_info=recompute_waveform_info,
+                                                      recompute_info=recompute_info,
                                                       max_spikes_for_pca=max_spikes_for_pca,
                                                       save_features_props=save_features_props, seed=seed)
-    elif 'amplitude_cutoff' in metric_names:
-        if recording is None:
-            raise ValueError("The recording cannot be None when computing amplitude_cutoff.")
-        else:
-            metric_calculator.compute_amplitudes(recording=recording, amp_method=amp_method, amp_peak=amp_peak,
-                                                 amp_frames_before=amp_frames_before,
-                                                 amp_frames_after=amp_frames_after,
-                                                 save_features_props=save_features_props, seed=seed)
-    elif 'snr' in metric_names:
+    if 'snr' in metric_names:
         if recording is None:
             raise ValueError("The recording cannot be None when computing snr.")
         else:

--- a/spiketoolkit/validation/validation_tools.py
+++ b/spiketoolkit/validation/validation_tools.py
@@ -37,7 +37,7 @@ def get_spike_times_metrics_data(sorting, sampling_frequency):
     return spike_times, spike_clusters
 
 
-def get_pca_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=np.inf,
+def get_pca_metric_data(recording, sorting, n_comp=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=np.inf,
                         max_spikes_for_pca=np.inf, recompute_info=True, save_features_props=False,
                         verbose=False, seed=0):
     '''
@@ -49,8 +49,8 @@ def get_pca_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2., dt
         The recording extractor
     sorting: SortingExtractor
         The sorting extractor
-    nPC: int
-        nPCFeatures in template-gui format
+    n_comp: int
+        n_compFeatures in template-gui format
     ms_before: float
         Time period in ms to cut waveforms before the spike events
     ms_after: float
@@ -86,7 +86,7 @@ def get_pca_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2., dt
     if len(sorting.get_unit_ids()) == 0:
         raise Exception("No units in the sorting result, can't compute any metric information.")
 
-    spike_times, spike_clusters, pc_features, pc_feature_ind = _get_pca_metric_data(recording, sorting, nPC=nPC,
+    spike_times, spike_clusters, pc_features, pc_feature_ind = _get_pca_metric_data(recording, sorting, n_comp=n_comp,
                                                                                     ms_before=ms_before,
                                                                                     ms_after=ms_after,
                                                                                     dtype=dtype,
@@ -163,7 +163,7 @@ def get_amplitude_metric_data(recording, sorting, amp_method='absolute', amp_pea
     return np.squeeze(recording.frame_to_time(spike_times)), np.squeeze(spike_clusters), np.squeeze(amplitudes)
 
 
-def get_all_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2., dtype=None, amp_method='absolute',
+def get_all_metric_data(recording, sorting, n_comp=3, ms_before=1., ms_after=2., dtype=None, amp_method='absolute',
                         amp_peak='both', amp_frames_before=3, amp_frames_after=3, max_spikes_per_unit=np.inf,
                         max_spikes_for_pca=np.inf, recompute_info=True, save_features_props=False,
                         verbose=False, seed=0):
@@ -176,8 +176,8 @@ def get_all_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2., dt
         The recording extractor
     sorting: SortingExtractor
         The sorting extractor
-    nPC: int
-        nPCFeatures in template-gui format
+    n_comp: int
+        n_compFeatures in template-gui format
     ms_before: float
         Time period in ms to cut waveforms before the spike events
     ms_after: float
@@ -234,7 +234,7 @@ def get_all_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2., dt
 
     spike_times, spike_times_amps, spike_times_pca, spike_clusters, spike_clusters_amps, spike_clusters_pca, \
     amplitudes, channel_map, pc_features, pc_feature_ind = _get_quality_metric_data(
-        recording, sorting, nPC=nPC,
+        recording, sorting, n_comp=n_comp,
         ms_before=ms_before, ms_after=ms_after,
         dtype=dtype, amp_method=amp_method,
         amp_peak=amp_peak,

--- a/spiketoolkit/validation/validation_tools.py
+++ b/spiketoolkit/validation/validation_tools.py
@@ -1,9 +1,10 @@
-from ..postprocessing.postprocessing_tools import _get_quality_metric_data
+from ..postprocessing.postprocessing_tools import _get_quality_metric_data, _get_pca_metric_data, \
+    _get_spike_times_clusters, _get_amp_metric_data
 import spikeextractors as se
 import numpy as np
 
 
-def get_firing_times_ids(sorting, sampling_frequency):
+def get_spike_times_metrics_data(sorting, sampling_frequency):
     '''
     Computes and returns the spike times in seconds and also returns
     along with cluster_ids needed for quality metrics
@@ -28,29 +29,144 @@ def get_firing_times_ids(sorting, sampling_frequency):
         raise Exception("No units in the sorting result, can't compute any metric information.")
 
     # spike times.npy and spike clusters.npy
-    spike_times = np.array([])
-    spike_clusters = np.array([])
+    spike_times, spike_clusters = _get_spike_times_clusters(sorting)
 
-    for i_u, unit_id in enumerate(sorting.get_unit_ids()):
-        spike_train = sorting.get_unit_spike_train(unit_id)
-        cl = [i_u] * len(sorting.get_unit_spike_train(unit_id))
-        spike_times = np.concatenate((spike_times, np.array(spike_train)))
-        spike_clusters = np.concatenate((spike_clusters, np.array(cl)))
-
-    sorting_idxs = np.argsort(spike_times)
-    spike_times = spike_times[sorting_idxs, np.newaxis]
-    spike_clusters = spike_clusters[sorting_idxs, np.newaxis]
-
-    spike_times = (spike_times / sampling_frequency).flatten('F')
-    spike_clusters = spike_clusters.astype(int).flatten('F')
+    spike_times = np.squeeze((spike_times / sampling_frequency))
+    spike_clusters = np.squeeze(spike_clusters.astype(int))
 
     return spike_times, spike_clusters
 
 
-def get_quality_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2., dtype=None, amp_method='absolute',
-                            amp_peak='both', amp_frames_before=3, amp_frames_after=3, max_spikes_per_unit=np.inf,
-                            max_spikes_for_pca=np.inf, recompute_waveform_info=True, save_features_props=False,
-                            verbose=False, seed=0):
+def get_pca_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=np.inf,
+                        max_spikes_for_pca=np.inf, recompute_info=True, save_features_props=False,
+                        verbose=False, seed=0):
+    '''
+    Computes and returns all data needed to compute all the quality metrics from SpikeMetrics
+
+    Parameters
+    ----------
+    recording: RecordingExtractor
+        The recording extractor
+    sorting: SortingExtractor
+        The sorting extractor
+    nPC: int
+        nPCFeatures in template-gui format
+    ms_before: float
+        Time period in ms to cut waveforms before the spike events
+    ms_after: float
+        Time period in ms to cut waveforms after the spike events
+    dtype: dtype
+        The numpy dtype of the waveforms
+    max_spikes_per_unit: int
+        The maximum number of spikes to extract per unit.
+    max_spikes_for_pca: int
+        The maximum number of spikes to use to compute PCA.
+    recompute_info: bool
+        If True, will always re-extract waveforms.
+    save_features_props: bool
+        If True, save all features and properties in the sorting extractor.
+    verbose: bool
+        If True output is verbose
+    seed: int
+            Random seed for reproducibility
+
+    Returns
+    -------
+    spike_times: numpy.ndarray (num_spikes x 0)
+        Spike times in frames
+    spike_clusters: numpy.ndarray (num_spikes x 0)
+        Cluster IDs for each spike time
+    pc_features: numpy.ndarray (num_spikes x num_pcs x num_channels)
+        Pre-computed PCs for blocks of channels around each spike
+    pc_feature_ind: numpy.ndarray (num_units x num_channels)
+        Channel indices of PCs for each unit
+    '''
+    if not isinstance(recording, se.RecordingExtractor) or not isinstance(sorting, se.SortingExtractor):
+        raise AttributeError()
+    if len(sorting.get_unit_ids()) == 0:
+        raise Exception("No units in the sorting result, can't compute any metric information.")
+
+    spike_times, spike_clusters, pc_features, pc_feature_ind = _get_pca_metric_data(recording, sorting, nPC=nPC,
+                                                                                    ms_before=ms_before,
+                                                                                    ms_after=ms_after,
+                                                                                    dtype=dtype,
+                                                                                    max_spikes_per_unit=
+                                                                                    max_spikes_per_unit,
+                                                                                    max_spikes_for_pca=
+                                                                                    max_spikes_for_pca,
+                                                                                    recompute_info=recompute_info,
+                                                                                    save_features_props=
+                                                                                    save_features_props,
+                                                                                    verbose=verbose, seed=seed)
+
+    return np.squeeze(recording.frame_to_time(spike_times)), np.squeeze(spike_clusters), pc_features, pc_feature_ind
+
+
+def get_amplitude_metric_data(recording, sorting, amp_method='absolute', amp_peak='both', amp_frames_before=3,
+                              amp_frames_after=3, max_spikes_per_unit=np.inf, recompute_info=True,
+                              save_features_props=False, seed=0):
+    '''
+    Computes and returns all data needed to compute all the quality metrics from SpikeMetrics
+
+    Parameters
+    ----------
+    recording: RecordingExtractor
+        The recording extractor
+    sorting: SortingExtractor
+        The sorting extractor
+    dtype: dtype
+        The numpy dtype of the waveforms
+    amp_method: str
+        If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
+        If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
+    amp_peak: str
+        If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
+    amp_frames_before: int
+        Frames before peak to compute amplitude
+    amp_frames_after: int
+        Frames after peak to compute amplitude
+    max_spikes_per_unit: int
+        The maximum number of spikes to extract per unit.
+    recompute_info: bool
+        If True, will always re-extract waveforms.
+    save_features_props: bool
+        If True, save all features and properties in the sorting extractor.
+    verbose: bool
+        If True output is verbose
+    seed: int
+            Random seed for reproducibility
+
+    Returns
+    -------
+    spike_times: numpy.ndarray (num_spikes x 0)
+        Spike times in frames
+    spike_clusters: numpy.ndarray (num_spikes x 0)
+        Cluster IDs for each spike time
+    amplitudes: numpy.ndarray (num_spikes x 0)
+        Amplitude value for each spike time
+    '''
+    if not isinstance(recording, se.RecordingExtractor) or not isinstance(sorting, se.SortingExtractor):
+        raise AttributeError()
+    if len(sorting.get_unit_ids()) == 0:
+        raise Exception("No units in the sorting result, can't compute any metric information.")
+
+    spike_times, spike_clusters, amplitudes = _get_amp_metric_data(recording, sorting,
+                                                                   amp_method=amp_method,
+                                                                   amp_peak=amp_peak,
+                                                                   amp_frames_before=amp_frames_before,
+                                                                   amp_frames_after=amp_frames_after,
+                                                                   max_spikes_per_unit=max_spikes_per_unit,
+                                                                   save_features_props=save_features_props,
+                                                                   recompute_info=recompute_info,
+                                                                   seed=seed)
+
+    return np.squeeze(recording.frame_to_time(spike_times)), np.squeeze(spike_clusters), np.squeeze(amplitudes)
+
+
+def get_all_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2., dtype=None, amp_method='absolute',
+                        amp_peak='both', amp_frames_before=3, amp_frames_after=3, max_spikes_per_unit=np.inf,
+                        max_spikes_for_pca=np.inf, recompute_info=True, save_features_props=False,
+                        verbose=False, seed=0):
     '''
     Computes and returns all data needed to compute all the quality metrics from SpikeMetrics
 
@@ -73,15 +189,15 @@ def get_quality_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2.
         If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
     amp_peak: str
         If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-    frames_before: int
+    amp_frames_before: int
         Frames before peak to compute amplitude
-    frames_after: float
+    amp_frames_after: int
         Frames after peak to compute amplitude
     max_spikes_per_unit: int
         The maximum number of spikes to extract per unit.
     max_spikes_for_pca: int
         The maximum number of spikes to use to compute PCA.
-    recompute_waveform_info: bool
+    recompute_info: bool
         If True, will always re-extract waveforms.
     save_features_props: bool
         If True, save all features and properties in the sorting extractor.
@@ -126,11 +242,11 @@ def get_quality_metric_data(recording, sorting, nPC=3, ms_before=1., ms_after=2.
         amp_frames_after=amp_frames_after,
         max_spikes_per_unit=max_spikes_per_unit,
         max_spikes_for_pca=max_spikes_for_pca,
-        recompute_waveform_info=recompute_waveform_info,
+        recompute_info=recompute_info,
         save_features_props=save_features_props,
         verbose=verbose, seed=seed)
 
-    return recording.frame_to_time(spike_times), recording.frame_to_time(spike_times_amps), \
-           recording.frame_to_time(spike_times_pca), spike_clusters.astype(int), \
-           spike_clusters_amps.astype(int), spike_clusters_pca.astype(int), \
-           amplitudes, pc_features, pc_feature_ind
+    return np.squeeze(recording.frame_to_time(spike_times)), np.squeeze(recording.frame_to_time(spike_times_amps)), \
+           np.squeeze(recording.frame_to_time(spike_times_pca)), np.squeeze(spike_clusters), \
+           np.squeeze(spike_clusters_amps), np.squeeze(spike_clusters_pca), \
+           np.squeeze(amplitudes), pc_features, pc_feature_ind


### PR DESCRIPTION
This allows to run metrics with a few number of spikes

- postprocessing tools can return indexes of spikes used to compute waveforms, amplitudes, and pc scores
- the indexes are used to extract two extra set otf spike_clusters and spike_times: spike_times_pca, spike_times_amps
- metrics using amplitudes or pca use this subsets of spike times (to get epochs idxs) and spike clusters and pass them to spikemetrics functions