### PR TITLE
removed sampling frequency from curation num spikes

### DIFF
--- a/spiketoolkit/curation/threshold_num_spikes.py
+++ b/spiketoolkit/curation/threshold_num_spikes.py
@@ -2,6 +2,8 @@ from .thresholdcurator import ThresholdCurator
 import spiketoolkit as st
 
 
+#No sampling frequency needed, special curator that does NOT use the metric calculator.
+
 class ThresholdNumSpikes(ThresholdCurator):
     curator_name = 'ThresholdNumSpikes'
     installed = True  # check at class level if installed or not
@@ -16,31 +18,20 @@ class ThresholdNumSpikes(ThresholdCurator):
     ]
     installation_mesg = ""  # err
 
-    def __init__(self, sorting, threshold=100, threshold_sign='less', sampling_frequency=None, metric_calculator=None):
+    def __init__(self, sorting, threshold=100, threshold_sign='less', metric_calculator=None):
         metric_name = 'num_spikes'
-        if sampling_frequency is None and sorting.get_sampling_frequency() is None:
-            raise ValueError("Please pass in a sampling frequency (your SortingExtractor does not have one specified)")
-        elif sampling_frequency is None:
-            self._sampling_frequency = sorting.get_sampling_frequency()
-        else:
-            self._sampling_frequency = sampling_frequency
-        if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(sorting,
-                                                                     sampling_frequency=self._sampling_frequency,
-                                                                     unit_ids=None, epoch_tuples=None, epoch_names=None)
-            self._metric_calculator.compute_num_spikes()
-        else:
+        if metric_calculator is not None:
             self._metric_calculator = metric_calculator
             if metric_name not in self._metric_calculator.get_metrics_dict().keys():
                 self._metric_calculator.compute_num_spikes()
-        num_spikes_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0]
-
+            num_spikes_epoch = self._metric_calculator.get_metrics_dict()[metric_name][0]
+        else:
+            num_spikes_epoch = [len(sorting.get_unit_spike_train(unit_id)) for unit_id in sorting.get_unit_ids()]
         ThresholdCurator.__init__(self, sorting=sorting, metrics_epoch=num_spikes_epoch)
         self.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
 
 
-def threshold_num_spikes(sorting, threshold=100, threshold_sign='less', sampling_frequency=None,
-                         metric_calculator=None):
+def threshold_num_spikes(sorting, threshold=100, threshold_sign='less', metric_calculator=None):
     '''
     Excludes units based on number of spikes.
 
@@ -55,8 +46,6 @@ def threshold_num_spikes(sorting, threshold=100, threshold_sign='less', sampling
         If 'less_or_equal', will remove any units with metric scores less than or equal to the given threshold.
         If 'greater', will remove any units with metric scores greater than the given threshold.
         If 'greater_or_equal', will remove any units with metric scores greater than or equal to the given threshold.
-    sampling_frequency: float
-        The sampling frequency of recording
     metric_calculator: MetricCalculator
         A metric calculator can be passed in with cached metrics.
     Returns
@@ -69,6 +58,5 @@ def threshold_num_spikes(sorting, threshold=100, threshold_sign='less', sampling
         sorting=sorting,
         threshold=threshold,
         threshold_sign=threshold_sign,
-        sampling_frequency=sampling_frequency,
         metric_calculator=metric_calculator
     )

--- a/spiketoolkit/tests/test_curation.py
+++ b/spiketoolkit/tests/test_curation.py
@@ -2,27 +2,35 @@ import spikeextractors as se
 import numpy as np
 from spiketoolkit.curation import threshold_snr, threshold_firing_rate, threshold_isi_violations, \
     threshold_num_spikes, threshold_presence_ratio
-from spiketoolkit.validation import compute_snrs, compute_firing_rates
+from spiketoolkit.validation import compute_snrs, compute_firing_rates, compute_num_spikes
 
+def test_thresh_num_spikes():
+    rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4, seed=0)
+    s_threshold = 25
+
+    sort_ns = threshold_num_spikes(sort, s_threshold, 'less')
+    new_ns = compute_num_spikes(sort_ns, rec.get_sampling_frequency())
+
+    assert np.all(new_ns >= s_threshold)
 
 def test_thresh_snr():
-    rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4)
+    rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4, seed=0)
     snr_thresh = 4
 
     sort_snr = threshold_snr(sort, rec, snr_thresh, 'less')
     new_snr = compute_snrs(sort_snr, rec)
 
-    assert np.all(new_snr > snr_thresh)
+    assert np.all(new_snr >= snr_thresh)
 
 
 def test_thresh_fr():
-    rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4)
+    rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4, seed=0)
     fr_thresh = 2
 
     sort_fr = threshold_firing_rate(sort, fr_thresh, 'less')
     new_fr = compute_firing_rates(sort_fr)
 
-    assert np.all(new_fr > fr_thresh)
+    assert np.all(new_fr >= fr_thresh)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I can't remove the sampling frequency requirement from the metric_calculator... but I can at least remove it from the curation tool. Tricky. Ideally, sampling_frequency should never be needed when computing num spikes.