### PR TITLE
removed returning single list when unit ids is 1

### DIFF
--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -196,16 +196,10 @@ def get_unit_waveforms(recording, sorting, unit_ids=None, grouping_property=None
             waveform_list.append(waveforms)
             ind_list.append(indices)
 
-    if len(waveform_list) == 1:
-        if return_idxs:
-            return waveform_list[0], ind_list[0]
-        else:
-            return waveform_list[0]
+    if return_idxs:
+        return waveform_list, ind_list
     else:
-        if return_idxs:
-            return waveform_list, ind_list
-        else:
-            return waveform_list
+        return waveform_list
 
 
 def get_unit_templates(recording, sorting, unit_ids=None, mode='median', grouping_property=None, save_as_property=True,
@@ -278,7 +272,7 @@ def get_unit_templates(recording, sorting, unit_ids=None, mode='median', groupin
                                            ms_before=ms_before, ms_after=ms_after, save_as_features=save_wf_as_features,
                                            grouping_property=grouping_property, dtype=dtype,
                                            compute_property_from_recording=compute_property_from_recording,
-                                           verbose=verbose, seed=seed)
+                                           verbose=verbose, seed=seed)[0]
         if mode == 'mean':
             template = np.mean(waveforms, axis=0)
         elif mode == 'median':
@@ -289,11 +283,7 @@ def get_unit_templates(recording, sorting, unit_ids=None, mode='median', groupin
         if save_as_property:
             sorting.set_unit_property(unit_id, 'template', template)
         template_list.append(template)
-
-    if len(template_list) == 1:
-        return template_list[0]
-    else:
-        return template_list
+    return template_list
 
 
 def get_unit_max_channels(recording, sorting, unit_ids=None, peak='both', mode='median', grouping_property=None,
@@ -362,7 +352,7 @@ def get_unit_max_channels(recording, sorting, unit_ids=None, peak='both', mode='
                                           dtype=dtype, ms_before=ms_before, ms_after=ms_after,
                                           grouping_property=grouping_property, save_as_property=save_as_property,
                                           compute_property_from_recording=compute_property_from_recording,
-                                          verbose=verbose, seed=seed)
+                                          verbose=verbose, seed=seed)[0]
         if peak == 'both':
             max_channel_idx = np.unravel_index(np.argmax(np.abs(template)),
                                                template.shape)[0]
@@ -380,10 +370,7 @@ def get_unit_max_channels(recording, sorting, unit_ids=None, peak='both', mode='
 
         max_list.append(max_channel)
 
-    if len(max_list) == 1:
-        return max_list[0]
-    else:
-        return max_list
+    return max_list
 
 
 def get_unit_amplitudes(recording, sorting, unit_ids=None, method='absolute', save_as_features=True, peak='both',
@@ -480,16 +467,10 @@ def get_unit_amplitudes(recording, sorting, unit_ids=None, method='absolute', sa
         amp_list.append(amps)
         ind_list.append(indices)
 
-    if len(amp_list) == 1:
-        if return_idxs:
-            return amp_list[0], ind_list[0]
-        else:
-            return amp_list[0]
+    if return_idxs:
+        return amp_list, ind_list
     else:
-        if return_idxs:
-            return amp_list, ind_list
-        else:
-            return amp_list
+        return amp_list
 
 
 def compute_unit_pca_scores(recording, sorting, unit_ids=None, n_comp=3, by_electrode=False, grouping_property=None,
@@ -636,16 +617,10 @@ def compute_unit_pca_scores(recording, sorting, unit_ids=None, n_comp=3, by_elec
                 features = pca_scores_list[i]
             sorting.set_unit_spike_features(unit_id, 'pca_scores', features)
 
-    if len(pca_scores_list) == 1:
-        if return_idxs:
-            return pca_scores_list[0], ind_list[0]
-        else:
-            return pca_scores_list[0]
+    if return_idxs:
+        return pca_scores_list, ind_list
     else:
-        if return_idxs:
-            return pca_scores_list, ind_list
-        else:
-            return pca_scores_list
+        return pca_scores_list
 
 
 def set_unit_properties_by_max_channel_properties(recording, sorting, property, unit_ids=None, peak='both',
@@ -710,7 +685,7 @@ def set_unit_properties_by_max_channel_properties(recording, sorting, property, 
                 max_chan = get_unit_max_channels(recording, sorting, unit_id, mode=mode, peak=peak,
                                                  max_spikes_per_unit=max_spikes_per_unit, dtype=dtype,
                                                  ms_before=ms_before, ms_after=ms_after, verbose=verbose,
-                                                 seed=seed)
+                                                 seed=seed)[0]
             sorting.set_unit_property(unit_id, property, recording.get_channel_property(max_chan, property))
 
 
@@ -1131,12 +1106,6 @@ def _get_phy_data(recording, sorting, n_comp, electrode_dimensions, grouping_pro
 
     # similar_templates.npy - [nTemplates, nTemplates] single
     templates = get_unit_templates(recording, sorting, save_as_property=save_features_props, seed=seed)
-
-    if not isinstance(templates, list):
-        if len(templates.shape) == 2:
-            # single unit
-            templates = templates.reshape(1, templates.shape[0], templates.shape[1])
-
     similar_templates = _compute_templates_similarity(templates)
 
     # templates.npy

--- a/spiketoolkit/tests/test_curation.py
+++ b/spiketoolkit/tests/test_curation.py
@@ -9,7 +9,7 @@ def test_thresh_num_spikes():
     s_threshold = 25
 
     sort_ns = threshold_num_spikes(sort, s_threshold, 'less')
-    new_ns = compute_num_spikes(sort_ns, rec.get_sampling_frequency())
+    new_ns = compute_num_spikes(sort_ns, rec.get_sampling_frequency())[0]
 
     assert np.all(new_ns >= s_threshold)
 
@@ -18,7 +18,7 @@ def test_thresh_snr():
     snr_thresh = 4
 
     sort_snr = threshold_snr(sort, rec, snr_thresh, 'less')
-    new_snr = compute_snrs(sort_snr, rec)
+    new_snr = compute_snrs(sort_snr, rec)[0]
 
     assert np.all(new_snr >= snr_thresh)
 
@@ -28,7 +28,7 @@ def test_thresh_fr():
     fr_thresh = 2
 
     sort_fr = threshold_firing_rate(sort, fr_thresh, 'less')
-    new_fr = compute_firing_rates(sort_fr)
+    new_fr = compute_firing_rates(sort_fr)[0]
 
     assert np.all(new_fr >= fr_thresh)
 

--- a/spiketoolkit/validation/metric_calculator.py
+++ b/spiketoolkit/validation/metric_calculator.py
@@ -359,8 +359,6 @@ class MetricCalculator:
         self.metrics['num_spikes'] = []
         for i, epoch in enumerate(self._epochs):
             self.metrics['num_spikes'].append(num_spikes_epochs[i])
-        if len(num_spikes_epochs) == 1:
-            num_spikes_epochs = num_spikes_epochs[0]
         return num_spikes_epochs
 
     def compute_firing_rates(self):
@@ -388,8 +386,6 @@ class MetricCalculator:
         self.metrics['firing_rate'] = []
         for i, epoch in enumerate(self._epochs):
             self.metrics['firing_rate'].append(firings_rates_epochs[i])
-        if len(firings_rates_epochs) == 1:
-            firings_rates_epochs = firings_rates_epochs[0]
         return firings_rates_epochs
 
     def compute_presence_ratios(self):
@@ -416,8 +412,6 @@ class MetricCalculator:
         self.metrics['presence_ratio'] = []
         for i, epoch in enumerate(self._epochs):
             self.metrics['presence_ratio'].append(presence_ratios_epochs[i])
-        if len(presence_ratios_epochs) == 1:
-            presence_ratios_epochs = presence_ratios_epochs[0]
         return presence_ratios_epochs
 
     def compute_isi_violations(self, isi_threshold=0.0015, min_isi=0.000166):
@@ -452,8 +446,6 @@ class MetricCalculator:
         self.metrics['isi_viol'] = []
         for i, epoch in enumerate(self._epochs):
             self.metrics['isi_viol'].append(isi_violations_epochs[i])
-        if len(isi_violations_epochs) == 1:
-            isi_violations_epochs = isi_violations_epochs[0]
         return isi_violations_epochs
 
     def compute_amplitude_cutoffs(self):
@@ -484,8 +476,6 @@ class MetricCalculator:
         self.metrics['amplitude_cutoff'] = []
         for i, epoch in enumerate(self._epochs):
             self.metrics['amplitude_cutoff'].append(amplitude_cutoffs_epochs[i])
-        if len(amplitude_cutoffs_epochs) == 1:
-            amplitude_cutoffs_epochs = amplitude_cutoffs_epochs[0]
         return amplitude_cutoffs_epochs
 
     def compute_snrs(self, snr_mode='mad', snr_noise_duration=10.0, max_spikes_per_unit_for_snr=1000,
@@ -547,8 +537,6 @@ class MetricCalculator:
         self.metrics['snr'] = []
         for i, epoch in enumerate(self._epochs):
             self.metrics['snr'].append(snrs_epochs[i])
-        if len(snrs_epochs) == 1:
-            snrs_epochs = snrs_epochs[0]
         return snrs_epochs
 
     def compute_drift_metrics(self, drift_metrics_interval_s=51, drift_metrics_min_spikes_per_interval=10):
@@ -601,9 +589,6 @@ class MetricCalculator:
         for i, epoch in enumerate(self._epochs):
             self.metrics['max_drift'].append(max_drifts_epochs[i])
             self.metrics['cumulative_drift'].append(cumulative_drifts_epochs[i])
-        if len(max_drifts_epochs) == 1:
-            max_drifts_epochs = max_drifts_epochs[0]
-            cumulative_drifts_epochs = cumulative_drifts_epochs[0]
         return max_drifts_epochs, cumulative_drifts_epochs
 
     def compute_silhouette_scores(self, max_spikes_for_silhouette=10000, seed=0):
@@ -647,8 +632,6 @@ class MetricCalculator:
         self.metrics['silhouette_score'] = []
         for i, epoch in enumerate(self._epochs):
             self.metrics['silhouette_score'].append(silhouette_scores_epochs[i])
-        if len(silhouette_scores_epochs) == 1:
-            silhouette_scores_epochs = silhouette_scores_epochs[0]
         return silhouette_scores_epochs
 
     def compute_isolation_distances(self, num_channels_to_compare=13, max_spikes_per_cluster=500, seed=0):
@@ -695,8 +678,6 @@ class MetricCalculator:
         self.metrics['isolation_distance'] = []
         for i, epoch in enumerate(self._epochs):
             self.metrics['isolation_distance'].append(isolation_distances_epochs[i])
-        if len(isolation_distances_epochs) == 1:
-            isolation_distances_epochs = isolation_distances_epochs[0]
         return isolation_distances_epochs
 
     def compute_l_ratios(self, num_channels_to_compare=13, max_spikes_per_cluster=500, seed=0):
@@ -743,8 +724,6 @@ class MetricCalculator:
         self.metrics['l_ratio'] = []
         for i, epoch in enumerate(self._epochs):
             self.metrics['l_ratio'].append(l_ratios_epochs[i])
-        if len(l_ratios_epochs) == 1:
-            l_ratios_epochs = l_ratios_epochs[0]
         return l_ratios_epochs
 
     def compute_d_primes(self, num_channels_to_compare=13, max_spikes_per_cluster=500, seed=0):
@@ -791,8 +770,6 @@ class MetricCalculator:
         self.metrics['d_prime'] = []
         for i, epoch in enumerate(self._epochs):
             self.metrics['d_prime'].append(d_primes_epochs[i])
-        if len(d_primes_epochs) == 1:
-            d_primes_epochs = d_primes_epochs[0]
         return d_primes_epochs
 
     def compute_nn_metrics(self, num_channels_to_compare=13, max_spikes_per_cluster=500, max_spikes_for_nn=10000,
@@ -858,9 +835,6 @@ class MetricCalculator:
         for i, epoch in enumerate(self._epochs):
             self.metrics['nn_hit_rate'].append(nn_hit_rates_epochs[i])
             self.metrics['nn_miss_rate'].append(nn_miss_rates_epochs[i])
-        if len(nn_hit_rates_epochs) == 1:
-            nn_hit_rates_epochs = nn_hit_rates_epochs[0]
-            nn_miss_rates_epochs = nn_miss_rates_epochs[0]
         return nn_hit_rates_epochs, nn_miss_rates_epochs
 
     def compute_metrics(self, isi_threshold=0.0015, min_isi=0.000166, snr_mode='mad', snr_noise_duration=10.0,

--- a/spiketoolkit/validation/quality_metrics.py
+++ b/spiketoolkit/validation/quality_metrics.py
@@ -23,7 +23,7 @@ def compute_num_spikes(sorting, sampling_frequency=None, unit_ids=None, epoch_tu
 
     Returns
     ----------
-    num_spikes_epochs: list
+    num_spikes_epochs: list of lists
         The spike counts of the sorted units in the given epochs.
     '''
 
@@ -34,11 +34,11 @@ def compute_num_spikes(sorting, sampling_frequency=None, unit_ids=None, epoch_tu
                                                        unit_ids=unit_ids,
                                                        epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     num_spikes_epochs = metric_calculator.compute_num_spikes()
-
     if save_as_property:
         if epoch_tuples is None:
+            num_spikes = num_spikes_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'num_spikes', num_spikes_epochs[i_u])
+                sorting.set_unit_property(u, 'num_spikes', num_spikes[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
 
@@ -67,7 +67,7 @@ def compute_firing_rates(sorting, sampling_frequency=None, unit_ids=None, epoch_
 
     Returns
     ----------
-    firing_rates_epochs: list
+    firing_rates_epochs: list of lists
         The firing rates of the sorted units in the given epochs.
     '''
 
@@ -81,8 +81,9 @@ def compute_firing_rates(sorting, sampling_frequency=None, unit_ids=None, epoch_
 
     if save_as_property:
         if epoch_tuples is None:
+            firings_rates = firings_rates_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'firing_rate', firings_rates_epochs[i_u])
+                sorting.set_unit_property(u, 'firing_rate', firings_rates[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
 
@@ -111,7 +112,7 @@ def compute_presence_ratios(sorting, sampling_frequency=None, unit_ids=None, epo
 
     Returns
     ----------
-    presence_ratios_epochs: list
+    presence_ratios_epochs: list of lists
         The presence ratios violations of the sorted units in the given epochs.
     '''
 
@@ -125,8 +126,9 @@ def compute_presence_ratios(sorting, sampling_frequency=None, unit_ids=None, epo
 
     if save_as_property:
         if epoch_tuples is None:
+            presence_ratios = presence_ratios_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'presence_ratio', presence_ratios_epochs[i_u])
+                sorting.set_unit_property(u, 'presence_ratio', presence_ratios[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
 
@@ -159,7 +161,7 @@ def compute_isi_violations(sorting, sampling_frequency=None, isi_threshold=0.001
 
     Returns
     ----------
-    isi_violations_epochs: list
+    isi_violations_epochs: list of lists
         The isi violations of the sorted units in the given epochs.
     '''
 
@@ -173,8 +175,9 @@ def compute_isi_violations(sorting, sampling_frequency=None, isi_threshold=0.001
 
     if save_as_property:
         if epoch_tuples is None:
+            isi_violations = isi_violations_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'isi_violation', isi_violations_epochs[i_u])
+                sorting.set_unit_property(u, 'isi_violation', isi_violations[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
 
@@ -223,7 +226,7 @@ def compute_amplitude_cutoffs(sorting, recording, amp_method='absolute', amp_pea
 
     Returns
     ----------
-    amplitude_cutoffs_epochs: list
+    amplitude_cutoffs_epochs: list of lists
         The amplitude cutoffs of the sorted units in the given epochs.
     '''
 
@@ -242,8 +245,9 @@ def compute_amplitude_cutoffs(sorting, recording, amp_method='absolute', amp_pea
 
     if save_as_property:
         if epoch_tuples is None:
+            amplitude_cutoffs = amplitude_cutoffs_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'amplitude_cutoff', amplitude_cutoffs_epochs[i_u])
+                sorting.set_unit_property(u, 'amplitude_cutoff', amplitude_cutoffs[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
 
@@ -291,7 +295,7 @@ def compute_snrs(sorting, recording, snr_mode='mad', snr_noise_duration=10.0, ma
 
     Returns
     ----------
-    snrs_epochs: list
+    snrs_epochs: list of lists
        The snrs of the sorted units in the given epochs.
     '''
 
@@ -309,8 +313,9 @@ def compute_snrs(sorting, recording, snr_mode='mad', snr_noise_duration=10.0, ma
 
     if save_as_property:
         if epoch_tuples is None:
+            snrs = snrs_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'snr', snrs_epochs[i_u])
+                sorting.set_unit_property(u, 'snr', snrs[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
     return snrs_epochs
@@ -368,9 +373,9 @@ def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift
 
     Returns
     ----------
-    max_drifts_epochs: list
+    max_drifts_epochs: list of lists
         The max drift of the given units over the specified epochs
-    cumulative_drifts_epochs: list
+    cumulative_drifts_epochs: list of lists
         The cumulative drifts of the given units over the specified epochs
     '''
     if unit_ids is None:
@@ -392,9 +397,11 @@ def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift
 
     if save_as_property:
         if epoch_tuples is None:
+            max_drifts = max_drifts_epochs[0]
+            cumulative_drifts = cumulative_drifts_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'max_drift', max_drifts_epochs[i_u])
-                sorting.set_unit_property(u, 'cumulative_drift', cumulative_drifts_epochs[i_u])
+                sorting.set_unit_property(u, 'max_drift', max_drifts[i_u])
+                sorting.set_unit_property(u, 'cumulative_drift', cumulative_drifts[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
 
@@ -451,7 +458,7 @@ def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=1000
 
     Returns
     ----------
-    silhouette_scores_epochs: list
+    silhouette_scores_epochs: list of lists
         The silhouette scores of the given units for the specified epochs.
     '''
     if unit_ids is None:
@@ -472,8 +479,9 @@ def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=1000
 
     if save_as_property:
         if epoch_tuples is None:
+            silhouette_scores = silhouette_scores_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'silhouette_score', silhouette_scores_epochs[i_u])
+                sorting.set_unit_property(u, 'silhouette_score', silhouette_scores[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
 
@@ -533,7 +541,7 @@ def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, 
 
     Returns
     ----------
-    isolation_distances_epochs: list
+    isolation_distances_epochs: list of lists
         Returns the isolation distances of each specified unit for the given epochs.
     '''
     if unit_ids is None:
@@ -555,8 +563,9 @@ def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, 
 
     if save_as_property:
         if epoch_tuples is None:
+            isolation_distances = isolation_distances_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'isolation_distance', isolation_distances_epochs[i_u])
+                sorting.set_unit_property(u, 'isolation_distance', isolation_distances[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
 
@@ -615,7 +624,7 @@ def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_
 
     Returns
     ----------
-    l_ratios_epochs: list
+    l_ratios_epochs: list of lists
         Returns the L ratios of each specified unit for the given epochs
     '''
     if unit_ids is None:
@@ -636,8 +645,9 @@ def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_
 
     if save_as_property:
         if epoch_tuples is None:
+            l_ratios = l_ratios_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'l_ratio', l_ratios_epochs[i_u])
+                sorting.set_unit_property(u, 'l_ratio', l_ratios[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
 
@@ -697,7 +707,7 @@ def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_
 
     Returns
     ----------
-    d_primes_epochs: list
+    d_primes_epochs: list of lists
         Returns the d primes of each specified unit for the given epochs.
     '''
     if unit_ids is None:
@@ -718,8 +728,9 @@ def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_
 
     if save_as_property:
         if epoch_tuples is None:
+            d_primes = d_primes_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'd_prime', d_primes_epochs[i_u])
+                sorting.set_unit_property(u, 'd_prime', d_primes[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
 
@@ -783,9 +794,9 @@ def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spike
 
     Returns
     ----------
-    nn_hit_rates_epochs: np.array
+    nn_hit_rates_epochs: list of lists
         The nearest neighbor hit rates for each specified unit.
-    nn_miss_rates_epochs: np.array
+    nn_miss_rates_epochs: list of lists
         The nearest neighbor miss rates for each specified unit.
     '''
     if unit_ids is None:
@@ -809,9 +820,11 @@ def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spike
 
     if save_as_property:
         if epoch_tuples is None:
+            nn_hit_rates = nn_hit_rates_epochs[0]
+            nn_miss_rates = nn_miss_rates_epochs[0]
             for i_u, u in enumerate(unit_ids):
-                sorting.set_unit_property(u, 'nn_hit_rates', nn_hit_rates_epochs[i_u])
-                sorting.set_unit_property(u, 'nn_miss_rates', nn_miss_rates_epochs[i_u])
+                sorting.set_unit_property(u, 'nn_hit_rates', nn_hit_rates[i_u])
+                sorting.set_unit_property(u, 'nn_miss_rates', nn_miss_rates[i_u])
         else:
             raise NotImplementedError("Quality metrics cannot be saved as properties if 'epochs_tuples' are given.")
     return nn_hit_rates_epochs, nn_miss_rates_epochs
@@ -910,7 +923,7 @@ def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_thresh
 
     Returns
     ----------
-    metrics_epochs : list
+    metrics_epochs : list of lists
         List of metrics data. The list consists of lists of metric data for each given epoch.
     OR
     metrics_df: pandas.DataFrame


### PR DESCRIPTION
We had the feature of returning a single list (instead of a list of list) when the number of units was 1. I removed this since it causes issues for downstream functions. Had to adjust a bunch of code to make it work.

@alejoe91 can you check elsewhere to see if this may cause problems? No problems in spiketoolkit I think, but not sure about widgets.