### PR TITLE
Waveform metric

### DIFF
--- a/spiketoolkit/curation/threshold_d_primes.py
+++ b/spiketoolkit/curation/threshold_d_primes.py
@@ -150,7 +150,7 @@ class ThresholdDPrimes(ThresholdCurator):
         metric_name = "d_prime"
 
         if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(
+            self._metric_calculator = st.validation.ValidationMetricCalculator(
                 sorting,
                 sampling_frequency=recording.get_sampling_frequency(),
                 unit_ids=None,
@@ -246,8 +246,8 @@ def threshold_d_primes(
         A list of strings for the names of the given epochs.
     save_as_property: bool
         If True, the metric is saved as sorting property
-    metric_calculator: MetricCalculator
-        A metric calculator can be passed in with cached metrics.
+    metric_calculator: ValidationMetricCalculator
+        A validation metric calculator can be passed in with cached metrics.
     seed: int
         Random seed for reproducibility
 

--- a/spiketoolkit/curation/threshold_firing_rate.py
+++ b/spiketoolkit/curation/threshold_firing_rate.py
@@ -24,7 +24,7 @@ class ThresholdFiringRate(ThresholdCurator):
         else:
             self._sampling_frequency = sampling_frequency
         if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(sorting,
+            self._metric_calculator = st.validation.ValidationMetricCalculator(sorting,
                                                                      sampling_frequency=self._sampling_frequency,
                                                                      unit_ids=None, epoch_tuples=None, epoch_names=None)
             self._metric_calculator.compute_firing_rates()
@@ -56,8 +56,8 @@ def threshold_firing_rate(sorting, threshold=15.0, threshold_sign='greater', sam
         If 'greater_or_equal', will remove any units with metric scores greater than or equal to the given threshold.
     sampling_frequency: float
         The sampling frequency of recording
-    metric_calculator: MetricCalculator
-        A metric calculator can be passed in with cached metrics.
+    metric_calculator: ValidationMetricCalculator
+        A validation metric calculator can be passed in with cached metrics.
     Returns
     -------
     thresholded_sorting: ThresholdFiringRate

--- a/spiketoolkit/curation/threshold_isi_violations.py
+++ b/spiketoolkit/curation/threshold_isi_violations.py
@@ -28,9 +28,11 @@ class ThresholdISIViolations(ThresholdCurator):
         else:
             self._sampling_frequency = sampling_frequency
         if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(sorting,
-                                                                     sampling_frequency=self._sampling_frequency,
-                                                                     unit_ids=None, epoch_tuples=None, epoch_names=None)
+            self._metric_calculator = st.validation.ValidationMetricCalculator(sorting,
+                                                                               sampling_frequency=
+                                                                               self._sampling_frequency,
+                                                                               unit_ids=None, epoch_tuples=None,
+                                                                               epoch_names=None)
             self._metric_calculator.compute_isi_violations(isi_threshold=isi_threshold, min_isi=min_isi)
         else:
             self._metric_calculator = metric_calculator
@@ -64,8 +66,8 @@ def threshold_isi_violations(sorting, threshold=5.0, threshold_sign='greater', i
             The minimum expected isi value.
     sampling_frequency: float
         The sampling frequency of recording
-    metric_calculator: MetricCalculator
-        A metric calculator can be passed in with cached metrics.
+    metric_calculator: ValidationMetricCalculator
+        A validation metric calculator can be passed in with cached metrics.
     Returns
     -------
     thresholded_sorting: ThresholdISIViolations

--- a/spiketoolkit/curation/threshold_l_ratios.py
+++ b/spiketoolkit/curation/threshold_l_ratios.py
@@ -246,8 +246,8 @@ def threshold_l_ratios(
         A list of strings for the names of the given epochs.
     save_as_property: bool
         If True, the metric is saved as sorting property
-    metric_calculator: MetricCalculator
-        A metric calculator can be passed in with cached metrics.
+    metric_calculator: ValidationMetricCalculator
+        A validation metric calculator can be passed in with cached metrics.
     seed: int
         Random seed for reproducibility
 

--- a/spiketoolkit/curation/threshold_num_spikes.py
+++ b/spiketoolkit/curation/threshold_num_spikes.py
@@ -46,8 +46,8 @@ def threshold_num_spikes(sorting, threshold=100, threshold_sign='less', metric_c
         If 'less_or_equal', will remove any units with metric scores less than or equal to the given threshold.
         If 'greater', will remove any units with metric scores greater than the given threshold.
         If 'greater_or_equal', will remove any units with metric scores greater than or equal to the given threshold.
-    metric_calculator: MetricCalculator
-        A metric calculator can be passed in with cached metrics.
+    metric_calculator: ValidationMetricCalculator
+        A validation metric calculator can be passed in with cached metrics.
     Returns
     -------
     thresholded_sorting: ThresholdNumSpikes

--- a/spiketoolkit/curation/threshold_presence_ratio.py
+++ b/spiketoolkit/curation/threshold_presence_ratio.py
@@ -23,9 +23,11 @@ class ThresholdPresenceRatio(ThresholdCurator):
         else:
             self._sampling_frequency = sampling_frequency
         if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(sorting,
-                                                                     sampling_frequency=self._sampling_frequency,
-                                                                     unit_ids=None, epoch_tuples=None, epoch_names=None)
+            self._metric_calculator = st.validation.ValidationMetricCalculator(sorting,
+                                                                               sampling_frequency=
+                                                                               self._sampling_frequency,
+                                                                               unit_ids=None, epoch_tuples=None,
+                                                                               epoch_names=None)
             self._metric_calculator.compute_presence_ratios()
         else:
             self._metric_calculator = metric_calculator
@@ -55,8 +57,8 @@ def threshold_presence_ratio(sorting, threshold=.50, threshold_sign='less', samp
         If 'greater_or_equal', will remove any units with metric scores greater than or equal to the given threshold.
     sampling_frequency: float
         The sampling frequency of recording
-    metric_calculator: MetricCalculator
-        A metric calculator can be passed in with cached metrics.
+    metric_calculator: ValidationMetricCalculator
+        A validation metric calculator can be passed in with cached metrics.
     Returns
     -------
     thresholded_sorting: ThresholdPresenceRatio

--- a/spiketoolkit/curation/threshold_silhouette_score.py
+++ b/spiketoolkit/curation/threshold_silhouette_score.py
@@ -244,8 +244,8 @@ def threshold_silhouette_score(
         If True, save all features and properties in the sorting extractor.
     save_as_property: bool
         If True, the metric is saved as sorting property
-    metric_calculator: MetricCalculator
-        A metric calculator can be passed in with cached metrics.
+    metric_calculator: ValidationMetricCalculator
+        A validation metric calculator can be passed in with cached metrics.
     seed: int
         Random seed for reproducibility
 

--- a/spiketoolkit/curation/threshold_snr.py
+++ b/spiketoolkit/curation/threshold_snr.py
@@ -32,7 +32,7 @@ class ThresholdSNR(ThresholdCurator):
                  save_features_props, metric_calculator, seed):
         metric_name = 'snr'
         if metric_calculator is None:
-            self._metric_calculator = st.validation.MetricCalculator(sorting,
+            self._metric_calculator = st.validation.ValidationMetricCalculator(sorting,
                                                                      sampling_frequency=recording.get_sampling_frequency(),
                                                                      unit_ids=None, epoch_tuples=None, epoch_names=None)
         else:
@@ -93,8 +93,8 @@ def threshold_snr(sorting, recording, threshold, threshold_sign,
         Low-pass frequency for optional filter (default 6000 Hz).
     save_features_props: bool
         If True, waveforms and templates are saved as sorting features/properties
-    metric_calculator: MetricCalculator
-        A metric calculator can be passed in with cached metrics.
+    metric_calculator: ValidationMetricCalculator
+        A validation metric calculator can be passed in with cached metrics.
     seed: int
         Random seed for reproducibility
     Returns

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -715,7 +715,7 @@ def set_unit_properties_by_max_channel_properties(recording, sorting, property, 
 def export_to_phy(recording, sorting, output_folder, n_comp=3, electrode_dimensions=None,
                   grouping_property=None, ms_before=1., ms_after=2., dtype=None, amp_method='absolute', amp_peak='both',
                   amp_frames_before=3, amp_frames_after=3, max_spikes_for_pca=1e5,
-                  recompute_info=True, save_features_props=False, write_waveforms=False, verbose=False,
+                  recompute_info=True, save_features_props=False, verbose=False,
                   seed=0):
     '''
     Exports paired recording and sorting extractors to phy template-gui format.

--- a/spiketoolkit/postprocessing/waveform_metric_calculator.py
+++ b/spiketoolkit/postprocessing/waveform_metric_calculator.py
@@ -1,0 +1,190 @@
+import numpy as np
+from spikeextractors import RecordingExtractor, SortingExtractor
+import spiketoolkit as st
+import pandas as pd
+from collections import defaultdict, OrderedDict
+from .postprocessing_tools import get_unit_waveforms, get_unit_templates, get_unit_max_channels
+import copy
+
+
+class WaveformMetricCalculator:
+    def __init__(self, sorting, recording=None, sampling_frequency=None, apply_filter=True, freq_min=300, freq_max=6000,
+                 unit_ids=None, epoch_tuples=None, epoch_names=None, max_spikes_per_unit=300, verbose=False):
+        '''
+        Computes and stores inital data along with the unit ids and epochs to be used for computing metrics.
+
+        Parameters
+        ----------
+        sorting: SortingExtractor
+            The sorting extractor to be evaluated.
+        recording: RecordingExtractor
+            The recording extractor to be stored. If None, the recording extractor can be added later.
+        sampling_frequency:
+            The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor.
+        apply_filter: bool
+            If True, recording is bandpass-filtered.
+        freq_min: float
+            High-pass frequency for optional filter (default 300 Hz).
+        freq_max: float
+            Low-pass frequency for optional filter (default 6000 Hz).
+        unit_ids: list
+            List of unit ids to compute metric for. If not specified, all units are used
+        epoch_tuples: list
+            A list of tuples with a start and end time for each epoch
+        epoch_names: list
+            A list of strings for the names of the given epochs.
+        verbose: bool
+            If True, progress bar is displayed
+        '''
+        if sampling_frequency is None and sorting.get_sampling_frequency() is None:
+            raise ValueError("Please pass in a sampling frequency (your SortingExtractor does not have one specified)")
+        elif sampling_frequency is None:
+            self._sampling_frequency = sorting.get_sampling_frequency()
+        else:
+            self._sampling_frequency = sampling_frequency
+
+        # only use units with spikes to avoid breaking metric calculation
+        num_spikes_per_unit = [len(sorting.get_unit_spike_train(unit_id)) for unit_id in sorting.get_unit_ids()]
+
+        if unit_ids is None:
+            unit_ids = sorting.get_unit_ids()
+        else:
+            unit_ids = set(unit_ids)
+            unit_ids = list(unit_ids.intersection(sorting.get_unit_ids()))
+
+        if len(unit_ids) == 0:
+            raise ValueError("No units found.")
+
+        spike_times, spike_clusters = get_spike_times_metrics_data(sorting, self._sampling_frequency)
+        assert isinstance(sorting, SortingExtractor), "'sorting' must be  a SortingExtractor object"
+        self._sorting = sorting
+        self._set_unit_ids(unit_ids)
+        self._set_epochs(epoch_tuples, epoch_names)
+        self._spike_times = spike_times
+        self._spike_clusters = spike_clusters
+        self._total_units = len(unit_ids)
+        self._unit_indices = _get_unit_indices(self._sorting, unit_ids)
+        # To compute this data, need to call all metric data
+        self._amplitudes = None
+        self._pc_features = None
+        self._pc_feature_ind = None
+        self._spike_clusters_pca = None
+        self._spike_clusters_amps = None
+        self._spike_times_pca = None
+        self._spike_times_amps = None
+        # Dictionary of cached metrics
+        self.metrics = {}
+        self.verbose = verbose
+
+        for epoch in self._epochs:
+            self._sorting.add_epoch(epoch_name=epoch[0], start_frame=epoch[1] * self._sampling_frequency,
+                                    end_frame=epoch[2] * self._sampling_frequency)
+        if recording is not None:
+            assert isinstance(recording, RecordingExtractor), "'sorting' must be  a RecordingExtractor object"
+            self.set_recording(recording, apply_filter=apply_filter, freq_min=freq_min, freq_max=freq_max)
+        else:
+            self._recording = None
+
+    def set_recording(self, recording, apply_filter=True, freq_min=300, freq_max=6000):
+        '''
+        Sets given recording extractor
+
+        Parameters
+        ----------
+        recording: RecordingExtractor
+            The recording extractor to be stored.
+        apply_filter: bool
+            If True, recording is bandpass-filtered.
+        freq_min: float
+            High-pass frequency for optional filter (default 300 Hz).
+        freq_max: float
+            Low-pass frequency for optional filter (default 6000 Hz).
+        '''
+        if apply_filter:
+            self._is_filtered = True
+            recording = st.preprocessing.bandpass_filter(recording=recording, freq_min=freq_min, freq_max=freq_max,
+                                                         cache_to_file=True)
+        else:
+            self._is_filtered = False
+        self._recording = recording
+        for epoch in self._epochs:
+            self._recording.add_epoch(epoch_name=epoch[0], start_frame=epoch[1] * self._sampling_frequency,
+                                      end_frame=epoch[2] * self._sampling_frequency)
+
+    def is_filtered(self):
+        return self._is_filtered
+
+    def compute_amplitudes(self, recording=None, amp_method='absolute', amp_peak='both', amp_frames_before=3, amp_frames_after=3,
+                           apply_filter=True, freq_min=300, freq_max=6000, save_features_props=False, seed=0):
+        '''
+        Computes and stores amplitudes for the amplitude cutoff metric
+
+        Parameters
+        ----------
+        recording: RecordingExtractor
+            The given recording extractor from which to extract amplitudes.
+        amp_method: str
+            If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
+            If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
+        amp_peak: str
+            If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
+        amp_frames_before: int
+            Frames before peak to compute amplitude
+        amp_frames_after: int
+            Frames after peak to compute amplitude
+        apply_filter: bool
+            If True, recording is bandpass-filtered.
+        freq_min: float
+            High-pass frequency for optional filter (default 300 Hz).
+        freq_max: float
+            Low-pass frequency for optional filter (default 6000 Hz).
+        save_features_props: bool
+            If true, it will save amplitudes in the sorting extractor.
+        seed: int
+            Random seed for reproducibility
+        '''
+        if recording is None:
+            if self._recording is None:
+                raise ValueError(
+                    "No recording given. Either call store_recording or pass a recording into this function")
+        else:
+            self.set_recording(recording, apply_filter=apply_filter, freq_min=freq_min, freq_max=freq_max)
+
+        spike_times, spike_clusters, amplitudes = get_amplitude_metric_data(self._recording, self._sorting,
+                                                                            amp_method=amp_method,
+                                                                            save_features_props=save_features_props,
+                                                                            amp_peak=amp_peak,
+                                                                            amp_frames_before=amp_frames_before,
+                                                                            amp_frames_after=amp_frames_after,
+                                                                            seed=seed)
+        self._amplitudes = amplitudes
+        self._spike_clusters_amps = spike_clusters
+        self._spike_times_amps = spike_times
+
+
+    def compute_duration(self):
+        pass
+
+    def compute_fwhm(self):
+        pass
+
+    def compute_peak_trough_ratio(self):
+        pass
+
+    def compute_repolarization_slope(self):
+        pass
+
+    def compute_recovery_slope(self):
+        pass
+
+    def compute_1d_metrics(self):
+        pass
+
+    def compute_waveform_spread(self):
+        pass
+
+    def compute_velocity_above_soma(self):
+        pass
+
+    def compute_velocity_below_soma(self):
+        pass

--- a/spiketoolkit/tests/test_validation.py
+++ b/spiketoolkit/tests/test_validation.py
@@ -3,12 +3,12 @@ from numpy.testing import assert_array_equal
 from spiketoolkit.validation import compute_isolation_distances, compute_isi_violations, compute_snrs, \
     compute_amplitude_cutoffs, compute_d_primes, compute_drift_metrics, compute_firing_rates, compute_l_ratios, \
     compute_metrics, compute_nn_metrics, compute_num_spikes, compute_presence_ratios, compute_silhouette_scores, \
-    MetricCalculator
+    ValidationMetricCalculator
 
 
 def test_calculator():
     rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4)
-    mc = MetricCalculator(sort, rec)
+    mc = ValidationMetricCalculator(sort, rec)
     mc.compute_all_metric_data()
 
     _ = mc.compute_metrics()

--- a/spiketoolkit/validation/__init__.py
+++ b/spiketoolkit/validation/__init__.py
@@ -3,4 +3,4 @@ from .validation_tools import get_all_metric_data, get_pca_metric_data, get_ampl
 from .quality_metrics import compute_num_spikes, compute_firing_rates, compute_presence_ratios, \
     compute_isi_violations, compute_amplitude_cutoffs, compute_snrs, compute_drift_metrics, compute_silhouette_scores, \
     compute_isolation_distances, compute_l_ratios, compute_d_primes, compute_nn_metrics, compute_metrics
-from .metric_calculator import MetricCalculator
+from .validation_metric_calculator import ValidationMetricCalculator

--- a/spiketoolkit/validation/quality_metrics.py
+++ b/spiketoolkit/validation/quality_metrics.py
@@ -30,9 +30,9 @@ def compute_num_spikes(sorting, sampling_frequency=None, unit_ids=None, epoch_tu
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=sampling_frequency,
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting, sampling_frequency=sampling_frequency,
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     num_spikes_epochs = metric_calculator.compute_num_spikes()
     if save_as_property:
         if epoch_tuples is None:
@@ -74,9 +74,9 @@ def compute_firing_rates(sorting, sampling_frequency=None, unit_ids=None, epoch_
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=sampling_frequency,
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting, sampling_frequency=sampling_frequency,
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     firings_rates_epochs = metric_calculator.compute_firing_rates()
 
     if save_as_property:
@@ -119,9 +119,9 @@ def compute_presence_ratios(sorting, sampling_frequency=None, unit_ids=None, epo
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=sampling_frequency,
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting, sampling_frequency=sampling_frequency,
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     presence_ratios_epochs = metric_calculator.compute_presence_ratios()
 
     if save_as_property:
@@ -168,9 +168,9 @@ def compute_isi_violations(sorting, sampling_frequency=None, isi_threshold=0.001
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=sampling_frequency,
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting, sampling_frequency=sampling_frequency,
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     isi_violations_epochs = metric_calculator.compute_isi_violations(isi_threshold=isi_threshold, min_isi=min_isi)
 
     if save_as_property:
@@ -185,7 +185,8 @@ def compute_isi_violations(sorting, sampling_frequency=None, isi_threshold=0.001
 
 
 def compute_amplitude_cutoffs(sorting, recording, amp_method='absolute', amp_peak='both', amp_frames_before=3,
-                              amp_frames_after=3, apply_filter=True, freq_min=300, freq_max=6000, save_features_props=False, 
+                              amp_frames_after=3, apply_filter=True, freq_min=300, freq_max=6000,
+                              save_features_props=False,
                               unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
     '''
     Computes and returns the amplitude cutoffs for the sorted dataset.
@@ -233,13 +234,14 @@ def compute_amplitude_cutoffs(sorting, recording, amp_method='absolute', amp_pea
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting,
+                                                                 sampling_frequency=recording.get_sampling_frequency(),
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     metric_calculator.compute_amplitudes(recording=recording, amp_method=amp_method, amp_peak=amp_peak,
                                          amp_frames_before=amp_frames_before,
-                                         amp_frames_after=amp_frames_after, apply_filter=apply_filter, 
-                                         freq_min=freq_min, freq_max=freq_max, 
+                                         amp_frames_after=amp_frames_after, apply_filter=apply_filter,
+                                         freq_min=freq_min, freq_max=freq_max,
                                          save_features_props=save_features_props, seed=seed)
     amplitude_cutoffs_epochs = metric_calculator.compute_amplitude_cutoffs()
 
@@ -255,7 +257,7 @@ def compute_amplitude_cutoffs(sorting, recording, amp_method='absolute', amp_pea
 
 
 def compute_snrs(sorting, recording, snr_mode='mad', snr_noise_duration=10.0, max_spikes_per_unit_for_snr=1000,
-                 recompute_info=True, apply_filter=True, freq_min=300, freq_max=6000, save_features_props=False, 
+                 recompute_info=True, apply_filter=True, freq_min=300, freq_max=6000, save_features_props=False,
                  unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
     '''
     Computes and stores snrs for the sorted units.
@@ -302,9 +304,10 @@ def compute_snrs(sorting, recording, snr_mode='mad', snr_noise_duration=10.0, ma
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting,
+                                                                 sampling_frequency=recording.get_sampling_frequency(),
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     metric_calculator.set_recording(recording, apply_filter=apply_filter, freq_min=freq_min, freq_max=freq_max)
     snrs_epochs = metric_calculator.compute_snrs(snr_mode=snr_mode, snr_noise_duration=snr_noise_duration,
                                                  max_spikes_per_unit_for_snr=max_spikes_per_unit_for_snr,
@@ -323,7 +326,8 @@ def compute_snrs(sorting, recording, snr_mode='mad', snr_noise_duration=10.0, ma
 
 def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift_metrics_min_spikes_per_interval=10,
                           n_comp=3, ms_before=1., ms_after=2., dtype=None, max_spikes_per_unit=300, recompute_info=True,
-                          max_spikes_for_pca=1e5, apply_filter=True, freq_min=300, freq_max=6000, save_features_props=False, 
+                          max_spikes_for_pca=1e5, apply_filter=True, freq_min=300, freq_max=6000,
+                          save_features_props=False,
                           unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
     '''
     Computes and returns the drift metrics for the sorted dataset.
@@ -381,9 +385,10 @@ def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting,
+                                                                 sampling_frequency=recording.get_sampling_frequency(),
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
@@ -410,7 +415,8 @@ def compute_drift_metrics(sorting, recording, drift_metrics_interval_s=51, drift
 
 def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=10000, n_comp=3, ms_before=1., ms_after=2.,
                               dtype=None, max_spikes_per_unit=300, recompute_info=True,
-                              max_spikes_for_pca=1e5, apply_filter=True, freq_min=300, freq_max=6000, save_features_props=False, 
+                              max_spikes_for_pca=1e5, apply_filter=True, freq_min=300, freq_max=6000,
+                              save_features_props=False,
                               unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
     '''
     Computes and returns the silhouette scores in the sorted dataset.
@@ -464,9 +470,10 @@ def compute_silhouette_scores(sorting, recording, max_spikes_for_silhouette=1000
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting,
+                                                                 sampling_frequency=recording.get_sampling_frequency(),
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
@@ -547,9 +554,10 @@ def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting,
+                                                                 sampling_frequency=recording.get_sampling_frequency(),
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
@@ -574,7 +582,7 @@ def compute_isolation_distances(sorting, recording, num_channels_to_compare=13, 
 
 def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500, n_comp=3, ms_before=1.,
                      ms_after=2., dtype=None, max_spikes_per_unit=300, recompute_info=True,
-                     max_spikes_for_pca=1e5, apply_filter=True, freq_min=300, freq_max=6000, save_features_props=False, 
+                     max_spikes_for_pca=1e5, apply_filter=True, freq_min=300, freq_max=6000, save_features_props=False,
                      unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
     '''
     Computes and returns the mahalanobis metric, l-ratio, for the sorted dataset.
@@ -630,9 +638,10 @@ def compute_l_ratios(sorting, recording, num_channels_to_compare=13, max_spikes_
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting,
+                                                                 sampling_frequency=recording.get_sampling_frequency(),
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
@@ -713,9 +722,10 @@ def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting,
+                                                                 sampling_frequency=recording.get_sampling_frequency(),
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
@@ -738,8 +748,8 @@ def compute_d_primes(sorting, recording, num_channels_to_compare=13, max_spikes_
 
 
 def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spikes_per_cluster=500,
-                       max_spikes_for_nn=10000, n_neighbors=4, n_comp=3, ms_before=1., ms_after=2., 
-                       dtype=None, max_spikes_per_unit=300, recompute_info=True, max_spikes_for_pca=1e5, 
+                       max_spikes_for_nn=10000, n_neighbors=4, n_comp=3, ms_before=1., ms_after=2.,
+                       dtype=None, max_spikes_per_unit=300, recompute_info=True, max_spikes_for_pca=1e5,
                        apply_filter=True, freq_min=300, freq_max=6000, save_features_props=False,
                        unit_ids=None, epoch_tuples=None, epoch_names=None, save_as_property=True, seed=0):
     '''
@@ -802,9 +812,10 @@ def compute_nn_metrics(sorting, recording, num_channels_to_compare=13, max_spike
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=recording.get_sampling_frequency(),
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting,
+                                                                 sampling_frequency=recording.get_sampling_frequency(),
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
     metric_calculator.compute_pca_scores(recording=recording, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                          dtype=dtype,
                                          max_spikes_per_unit=max_spikes_per_unit,
@@ -835,9 +846,9 @@ def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_thresh
                     drift_metrics_interval_s=51, drift_metrics_min_spikes_per_interval=10,
                     max_spikes_for_silhouette=10000, num_channels_to_compare=13, max_spikes_per_cluster=500,
                     max_spikes_for_nn=10000, n_neighbors=4, n_comp=3, ms_before=1., ms_after=2., dtype=None,
-                    max_spikes_per_unit=300,  amp_method='absolute', amp_peak='both', amp_frames_before=3, 
-                    amp_frames_after=3, recompute_info=True,  max_spikes_for_pca=1e5, apply_filter=True, 
-                    freq_min=300, freq_max=6000, save_features_props=False, metric_names=None, unit_ids=None, 
+                    max_spikes_per_unit=300, amp_method='absolute', amp_peak='both', amp_frames_before=3,
+                    amp_frames_after=3, recompute_info=True, max_spikes_for_pca=1e5, apply_filter=True,
+                    freq_min=300, freq_max=6000, save_features_props=False, metric_names=None, unit_ids=None,
                     epoch_tuples=None, epoch_names=None, return_dataframe=False, seed=0):
     '''
     Computes and returns all specified metrics for the sorted dataset.
@@ -947,9 +958,9 @@ def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_thresh
     if recording is not None:
         sampling_frequency = recording.get_sampling_frequency()
 
-    metric_calculator = st.validation.MetricCalculator(sorting, sampling_frequency=sampling_frequency,
-                                                       unit_ids=unit_ids,
-                                                       epoch_tuples=epoch_tuples, epoch_names=epoch_names)
+    metric_calculator = st.validation.ValidationMetricCalculator(sorting, sampling_frequency=sampling_frequency,
+                                                                 unit_ids=unit_ids,
+                                                                 epoch_tuples=epoch_tuples, epoch_names=epoch_names)
 
     if 'max_drift' in metric_names or 'cumulative_drift' in metric_names or 'silhouette_score' in metric_names \
             or 'isolation_distance' in metric_names or 'l_ratio' in metric_names or 'd_prime' in metric_names \
@@ -975,8 +986,8 @@ def compute_metrics(sorting, recording=None, sampling_frequency=None, isi_thresh
         else:
             metric_calculator.compute_amplitudes(recording=recording, amp_method=amp_method, amp_peak=amp_peak,
                                                  amp_frames_before=amp_frames_before,
-                                                 amp_frames_after=amp_frames_after, apply_filter=apply_filter, 
-                                                 freq_min=freq_min, freq_max=freq_max, 
+                                                 amp_frames_after=amp_frames_after, apply_filter=apply_filter,
+                                                 freq_min=freq_min, freq_max=freq_max,
                                                  save_features_props=save_features_props, seed=seed)
     elif 'snr' in metric_names:
         if recording is None:

--- a/spiketoolkit/validation/validation_metric_calculator.py
+++ b/spiketoolkit/validation/validation_metric_calculator.py
@@ -11,9 +11,9 @@ import copy
 from spiketoolkit.curation.thresholdcurator import ThresholdCurator
 
 
-class MetricCalculator:
+class ValidationMetricCalculator:
     def __init__(self, sorting, recording=None, sampling_frequency=None, apply_filter=True, freq_min=300, freq_max=6000, 
-                 unit_ids=None, epoch_tuples=None, epoch_names=None, verbose=False):
+                 unit_ids=None, epoch_tuples=None, epoch_names=None, max_spikes_per_unit=None, verbose=False):
         '''
         Computes and stores inital data along with the unit ids and epochs to be used for computing metrics.
 


### PR DESCRIPTION
- introduce concept of WaveformMetricCalculator in postprocessing
- change MetricCalculator to ValidationMetricCalculator

**TODO** 
- port code from https://github.com/AllenInstitute/ecephys_spike_sorting/tree/master/ecephys_spike_sorting/modules/mean_waveforms to WaveformMetricCalculator class and functions
- add tests for waveforms metrics