### PR TITLE
Some fixes and refractor

### DIFF
--- a/spiketoolkit/preprocessing/center.py
+++ b/spiketoolkit/preprocessing/center.py
@@ -1,5 +1,6 @@
 from spikeextractors import RecordingExtractor
 from .transform import TransformRecording
+import numpy as np
 
 
 class CenterRecording(TransformRecording):
@@ -9,18 +10,23 @@ class CenterRecording(TransformRecording):
     preprocessor_gui_params = []
     installation_mesg = ""  # err
 
-    def __init__(self, recording):
+    def __init__(self, recording, mode):
         if not isinstance(recording, RecordingExtractor):
             raise ValueError("'recording' must be a RecordingExtractor")
         self._recording = recording
         self._scalar = 1
-        self._offset = -self._recording.get_traces().mean(axis=1)
+        self._mode = mode
+        assert self._mode in ['mean', 'median'], "'mode' can be 'mean' or 'median'"
+        if self._mode == 'mean':
+            self._offset = -np.mean(self._recording.get_traces(), axis=1)
+        else:
+            self._offset = -np.median(self._recording.get_traces(), axis=1)
         TransformRecording.__init__(self, self._recording, scalar=self._scalar, offset=self._offset)
         self.copy_channel_properties(recording=self._recording)
-        self._kwargs = {'recording': recording.make_serialized_dict(), 'scalar': self._scalar, 'offset': self._offset}
+        self._kwargs = {'recording': recording.make_serialized_dict(), 'mode': self._mode}
 
 
-def center(recording):
+def center(recording, mode='median'):
     '''
     Removes the offset of the traces channel by channel.
 
@@ -28,9 +34,11 @@ def center(recording):
     ----------
     recording: RecordingExtractor
         The recording extractor to be transformed
+    mode: str
+        'median' (default) or 'mean'
     Returns
     -------
     rcenter: CenterRecording
         The output recording extractor object
     '''
-    return CenterRecording(recording=recording)
+    return CenterRecording(recording=recording, mode=mode)

--- a/spiketoolkit/preprocessing/center.py
+++ b/spiketoolkit/preprocessing/center.py
@@ -33,6 +33,4 @@ def center(recording):
     rcenter: CenterRecording
         The output recording extractor object
     '''
-    return CenterRecording(
-        recording=recording
-    )
+    return CenterRecording(recording=recording)

--- a/spiketoolkit/preprocessing/center.py
+++ b/spiketoolkit/preprocessing/center.py
@@ -1,0 +1,38 @@
+from spikeextractors import RecordingExtractor
+from .transform import TransformRecording
+
+
+class CenterRecording(TransformRecording):
+
+    preprocessor_name = 'Center'
+    installed = True  # check at class level if installed or not
+    preprocessor_gui_params = []
+    installation_mesg = ""  # err
+
+    def __init__(self, recording):
+        if not isinstance(recording, RecordingExtractor):
+            raise ValueError("'recording' must be a RecordingExtractor")
+        self._recording = recording
+        self._scalar = 1
+        self._offset = -self._recording.get_traces().mean(axis=1)
+        TransformRecording.__init__(self, self._recording, scalar=self._scalar, offset=self._offset)
+        self.copy_channel_properties(recording=self._recording)
+        self._kwargs = {'recording': recording.make_serialized_dict(), 'scalar': self._scalar, 'offset': self._offset}
+
+
+def center(recording):
+    '''
+    Removes the offset of the traces channel by channel.
+
+    Parameters
+    ----------
+    recording: RecordingExtractor
+        The recording extractor to be transformed
+    Returns
+    -------
+    rcenter: CenterRecording
+        The output recording extractor object
+    '''
+    return CenterRecording(
+        recording=recording
+    )

--- a/spiketoolkit/preprocessing/clip.py
+++ b/spiketoolkit/preprocessing/clip.py
@@ -51,7 +51,7 @@ class ClipRecording(RecordingExtractor):
         return traces
 
 
-def clip_traces(recording, a_min=None, a_max=None):
+def clip(recording, a_min=None, a_max=None):
     '''
     Limit the values of the data between a_min and a_max. Values exceeding the
     range will be set to the minimum or maximum, respectively.

--- a/spiketoolkit/preprocessing/clip.py
+++ b/spiketoolkit/preprocessing/clip.py
@@ -2,8 +2,8 @@ from spikeextractors import RecordingExtractor
 import numpy as np
 
 
-class ClipTracesRecording(RecordingExtractor):
-    preprocessor_name = 'ClipTraces'
+class ClipRecording(RecordingExtractor):
+    preprocessor_name = 'Clip'
     installed = True  # check at class level if installed or not
     preprocessor_gui_params = [
         {'name': 'a_min', 'type': 'float',
@@ -72,6 +72,6 @@ def clip_traces(recording, a_min=None, a_max=None):
     rescaled_traces: ClipTracesRecording
         The clipped traces recording extractor object
     '''
-    return ClipTracesRecording(
+    return ClipRecording(
         recording=recording, a_min=a_min, a_max=a_max
     )

--- a/spiketoolkit/preprocessing/filterrecording.py
+++ b/spiketoolkit/preprocessing/filterrecording.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 import spikeextractors as se
 import numpy as np
 from spikeextractors import RecordingExtractor
+from .transform import TransformRecording
 
 
 class FilterRecording(RecordingExtractor):
@@ -17,6 +18,14 @@ class FilterRecording(RecordingExtractor):
             self._filtered_cache_chunks = None
         self._traces = None
         se.RecordingExtractor.__init__(self)
+        dtype = str(self._recording.get_dtype())
+        if dtype.startswith('uint'):
+            dtype_signed = dtype[1:]
+            exp_idx = dtype.find('int') + 3
+            exp = int(dtype[exp_idx:])
+            offset = - 2**(exp - 1) - 1
+            self._recording = TransformRecording(self._recording, offset=offset)
+            print(f"dtype converted from {dtype} to {dtype_signed} before filtering")
         self.copy_channel_properties(recording)
 
     def get_channel_ids(self):

--- a/spiketoolkit/preprocessing/preprocessinglist.py
+++ b/spiketoolkit/preprocessing/preprocessinglist.py
@@ -5,11 +5,12 @@ from .common_reference import common_reference, CommonReferenceRecording
 from .resample import resample, ResampleRecording
 from .rectify import rectify, RectifyRecording
 from .remove_artifacts import remove_artifacts, RemoveArtifactsRecording
-from .transform_traces import transform_traces, TransformTracesRecording
+from .transform import transform_traces, TransformRecording
 from .remove_bad_channels import remove_bad_channels, RemoveBadChannelsRecording
 from .normalize_by_quantile import normalize_by_quantile, NormalizeByQuantileRecording
-from .clip_traces import clip_traces, ClipTracesRecording
+from .clip import clip_traces, ClipRecording
 from .blank_saturation import blank_saturation, BlankSaturationRecording
+from .center import center, CenterRecording
 
 preprocessers_full_list = [
     BandpassFilterRecording,
@@ -20,10 +21,11 @@ preprocessers_full_list = [
     RectifyRecording,
     RemoveArtifactsRecording,
     RemoveBadChannelsRecording,
-    TransformTracesRecording,
+    TransformRecording,
     NormalizeByQuantileRecording,
-    ClipTracesRecording,
-    BlankSaturationRecording
+    ClipRecording,
+    BlankSaturationRecording,
+    CenterRecording
 ]
 
 installed_preprocessers_list = [pp for pp in preprocessers_full_list if pp.installed]

--- a/spiketoolkit/preprocessing/preprocessinglist.py
+++ b/spiketoolkit/preprocessing/preprocessinglist.py
@@ -5,10 +5,10 @@ from .common_reference import common_reference, CommonReferenceRecording
 from .resample import resample, ResampleRecording
 from .rectify import rectify, RectifyRecording
 from .remove_artifacts import remove_artifacts, RemoveArtifactsRecording
-from .transform import transform_traces, TransformRecording
+from .transform import transform, TransformRecording
 from .remove_bad_channels import remove_bad_channels, RemoveBadChannelsRecording
 from .normalize_by_quantile import normalize_by_quantile, NormalizeByQuantileRecording
-from .clip import clip_traces, ClipRecording
+from .clip import clip, ClipRecording
 from .blank_saturation import blank_saturation, BlankSaturationRecording
 from .center import center, CenterRecording
 

--- a/spiketoolkit/preprocessing/transform.py
+++ b/spiketoolkit/preprocessing/transform.py
@@ -1,9 +1,9 @@
 from spikeextractors import RecordingExtractor
 import numpy as np
 
-class TransformTracesRecording(RecordingExtractor):
+class TransformRecording(RecordingExtractor):
 
-    preprocessor_name = 'TransformTraces'
+    preprocessor_name = 'Transform'
     installed = True  # check at class level if installed or not
     preprocessor_gui_params = [
         {'name': 'scalar', 'type': 'float or array', 'title': "Scalar for all traces or each channel "
@@ -58,7 +58,7 @@ class TransformTracesRecording(RecordingExtractor):
             else:
                 channel_idxs = np.array([self._recording.get_channel_ids().index(ch) for ch in channel_ids])
                 offset = self._offset[channel_idxs]
-            traces = np.array([t + o for (t, o) in zip(traces, offset)])
+            traces = np.array([(t + o) for (t, o) in zip(traces, offset)])
         return traces
 
 
@@ -80,6 +80,6 @@ def transform_traces(recording, scalar=1, offset=0):
     transform_traces: TransformTracesRecording
         The transformed traces recording extractor object
     '''
-    return TransformTracesRecording(
+    return TransformRecording(
         recording=recording, scalar=scalar, offset=offset
     )

--- a/spiketoolkit/preprocessing/transform.py
+++ b/spiketoolkit/preprocessing/transform.py
@@ -46,20 +46,20 @@ class TransformRecording(RecordingExtractor):
             traces = traces*self._scalar
         else:
             if len(self._scalar) == len(channel_ids):
-                scalar = self._scalar
+                scalar = np.array(self._scalar)
             else:
                 channel_idxs = np.array([self._recording.get_channel_ids().index(ch) for ch in channel_ids])
                 scalar = np.array(self._scalar)[channel_idxs]
-            traces = np.array([t * s for (t, s) in zip(traces, scalar)])
+            traces = traces * scalar[:, np.newaxis]
         if isinstance(self._offset, (int, float, np.integer, np.float)):
             traces = traces + self._offset
         else:
             if len(self._offset) == len(channel_ids):
-                offset = self._offset
+                offset = np.array(self._offset)
             else:
                 channel_idxs = np.array([self._recording.get_channel_ids().index(ch) for ch in channel_ids])
                 offset = np.array(self._offset)[channel_idxs]
-            traces = np.array([(t + o) for (t, o) in zip(traces, offset)])
+            traces = traces + offset[:, np.newaxis]
         return traces
 
 

--- a/spiketoolkit/preprocessing/transform.py
+++ b/spiketoolkit/preprocessing/transform.py
@@ -1,6 +1,7 @@
 from spikeextractors import RecordingExtractor
 import numpy as np
 
+
 class TransformRecording(RecordingExtractor):
 
     preprocessor_name = 'Transform'
@@ -13,7 +14,7 @@ class TransformRecording(RecordingExtractor):
     ]
     installation_mesg = ""  # err
 
-    def __init__(self, recording, scalar=1, offset=0):
+    def __init__(self, recording, scalar=1., offset=0.):
         if not isinstance(recording, RecordingExtractor):
             raise ValueError("'recording' must be a RecordingExtractor")
         self._recording = recording
@@ -48,7 +49,7 @@ class TransformRecording(RecordingExtractor):
                 scalar = self._scalar
             else:
                 channel_idxs = np.array([self._recording.get_channel_ids().index(ch) for ch in channel_ids])
-                scalar = self._scalar[channel_idxs]
+                scalar = np.array(self._scalar)[channel_idxs]
             traces = np.array([t * s for (t, s) in zip(traces, scalar)])
         if isinstance(self._offset, (int, float, np.integer, np.float)):
             traces = traces + self._offset
@@ -57,12 +58,12 @@ class TransformRecording(RecordingExtractor):
                 offset = self._offset
             else:
                 channel_idxs = np.array([self._recording.get_channel_ids().index(ch) for ch in channel_ids])
-                offset = self._offset[channel_idxs]
+                offset = np.array(self._offset)[channel_idxs]
             traces = np.array([(t + o) for (t, o) in zip(traces, offset)])
         return traces
 
 
-def transform_traces(recording, scalar=1, offset=0):
+def transform(recording, scalar=1, offset=0):
     '''
     Transforms the traces from the given recording extractor with a scalar
     and offset. New traces = traces*scalar + offset.

--- a/spiketoolkit/preprocessing/transform_traces.py
+++ b/spiketoolkit/preprocessing/transform_traces.py
@@ -6,8 +6,10 @@ class TransformTracesRecording(RecordingExtractor):
     preprocessor_name = 'TransformTraces'
     installed = True  # check at class level if installed or not
     preprocessor_gui_params = [
-        {'name': 'scalar', 'type': 'float', 'title': "Scalar for the traces of the recording extractor"},
-        {'name': 'offset', 'type': 'float', 'title': "Offset for the traces of the recording extractor"},
+        {'name': 'scalar', 'type': 'float or array', 'title': "Scalar for all traces or each channel "
+                                                              "of the recording extractor"},
+        {'name': 'offset', 'type': 'float or array', 'title': "Offset for all traces or each channel"
+                                                              "of the recording extractor"},
     ]
     installation_mesg = ""  # err
 
@@ -21,7 +23,6 @@ class TransformTracesRecording(RecordingExtractor):
         self.copy_channel_properties(recording=self._recording)
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'scalar': scalar, 'offset': offset}
-
 
     def get_sampling_frequency(self):
         return self._recording.get_sampling_frequency()
@@ -40,7 +41,25 @@ class TransformTracesRecording(RecordingExtractor):
         if channel_ids is None:
             channel_ids = self.get_channel_ids()
         traces = self._recording.get_traces(channel_ids=channel_ids, start_frame=start_frame, end_frame=end_frame)
-        return traces*self._scalar + self._offset
+        if isinstance(self._scalar, (int, float, np.integer, np.float)):
+            traces = traces*self._scalar
+        else:
+            if len(self._scalar) == len(channel_ids):
+                scalar = self._scalar
+            else:
+                channel_idxs = np.array([self._recording.get_channel_ids().index(ch) for ch in channel_ids])
+                scalar = self._scalar[channel_idxs]
+            traces = np.array([t * s for (t, s) in zip(traces, scalar)])
+        if isinstance(self._offset, (int, float, np.integer, np.float)):
+            traces = traces + self._offset
+        else:
+            if len(self._offset) == len(channel_ids):
+                offset = self._offset
+            else:
+                channel_idxs = np.array([self._recording.get_channel_ids().index(ch) for ch in channel_ids])
+                offset = self._offset[channel_idxs]
+            traces = np.array([t + o for (t, o) in zip(traces, offset)])
+        return traces
 
 
 def transform_traces(recording, scalar=1, offset=0):

--- a/spiketoolkit/tests/test_preprocessing.py
+++ b/spiketoolkit/tests/test_preprocessing.py
@@ -91,10 +91,17 @@ def test_blank_saturation():
 
 @pytest.mark.implemented
 def test_center():
-    rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4)
+    rec = create_dumpable_recording(duration=10, num_channels=4, folder='test')
 
-    rec_c = center(rec)
-    assert np.allclose(rec_c.get_traces().mean(axis=1), 0)
+    rec_c = center(rec, mode='mean')
+    assert np.allclose(np.mean(rec_c.get_traces(), axis=1), 0, atol=0.001)
+    check_dumping(rec_c)
+
+    rec_c = center(rec, mode='median')
+    assert np.allclose(np.median(rec_c.get_traces(), axis=1), 0, atol=0.001)
+    check_dumping(rec_c)
+
+    shutil.rmtree('test')
 
 
 @pytest.mark.implemented
@@ -264,13 +271,13 @@ def test_transform():
     offset = 50
 
     rec_t = transform(rec, scalar=scalar, offset=offset)
-    assert np.allclose(rec_t.get_traces(), scalar * rec.get_traces() + offset)
+    assert np.allclose(rec_t.get_traces(), scalar * rec.get_traces() + offset, atol=0.001)
 
     scalars = np.random.randn(4)
     offsets = np.random.randn(4)
     rec_t_arr = transform(rec, scalar=scalars, offset=offsets)
     for (tt, to, s, o) in zip(rec_t_arr.get_traces(), rec.get_traces(), scalars, offsets):
-        assert np.allclose(tt, s * to + o)
+        assert np.allclose(tt, s * to + o, atol=0.001)
 
     check_dumping(rec_t)
     check_dumping(rec_t_arr)
@@ -299,6 +306,7 @@ if __name__ == '__main__':
     # test_bandpass_filter_with_cache()
     # test_blank_saturation()
     # test_clip_traces()
+    test_center()
     # test_common_reference()
     # test_norm_by_quantile()
     # test_notch_filter()
@@ -306,5 +314,5 @@ if __name__ == '__main__':
     # test_remove_artifacts()
     # test_remove_bad_channels()
     # test_resample()
-    test_transform_traces()
+    # test_transform()
     # test_whiten()

--- a/spiketoolkit/tests/test_preprocessing.py
+++ b/spiketoolkit/tests/test_preprocessing.py
@@ -3,8 +3,8 @@ import spikeextractors as se
 import pytest
 import shutil
 from spiketoolkit.tests.utils import check_signal_power_signal1_below_signal2
-from spiketoolkit.preprocessing import bandpass_filter, blank_saturation, center, clip_traces, common_reference, \
-    normalize_by_quantile, notch_filter, rectify, remove_artifacts, remove_bad_channels, resample, transform_traces, \
+from spiketoolkit.preprocessing import bandpass_filter, blank_saturation, center, clip, common_reference, \
+    normalize_by_quantile, notch_filter, rectify, remove_artifacts, remove_bad_channels, resample, transform, \
     whiten
 from spiketoolkit.tests.utils import check_dumping, create_dumpable_recording
 
@@ -98,10 +98,10 @@ def test_center():
 
 
 @pytest.mark.implemented
-def test_clip_traces():
+def test_clip():
     rec = create_dumpable_recording(duration=10, num_channels=4, folder='test')
     threshold = 5
-    rec_clip = clip_traces(rec, a_min=-threshold, a_max=threshold)
+    rec_clip = clip(rec, a_min=-threshold, a_max=threshold)
 
     index_below_threshold = np.where(rec.get_traces() < -threshold)
     index_above_threshold = np.where(rec.get_traces() > threshold)
@@ -257,18 +257,18 @@ def test_resample():
 
 
 @pytest.mark.implemented
-def test_transform_traces():
+def test_transform():
     rec = create_dumpable_recording(duration=10, num_channels=4, folder='test')
 
     scalar = 3
     offset = 50
 
-    rec_t = transform_traces(rec, scalar=scalar, offset=offset)
+    rec_t = transform(rec, scalar=scalar, offset=offset)
     assert np.allclose(rec_t.get_traces(), scalar * rec.get_traces() + offset)
 
     scalars = np.random.randn(4)
     offsets = np.random.randn(4)
-    rec_t_arr = transform_traces(rec, scalar=scalars, offset=offsets)
+    rec_t_arr = transform(rec, scalar=scalars, offset=offsets)
     for (tt, to, s, o) in zip(rec_t_arr.get_traces(), rec.get_traces(), scalars, offsets):
         assert np.allclose(tt, s * to + o)
 
@@ -294,17 +294,17 @@ def test_whiten():
     check_dumping(rec_w)
     shutil.rmtree('test')
 
-# if __name__ == '__main__':
-# test_bandpass_filter()
-# test_bandpass_filter_with_cache()
-# test_blank_saturation()
-# test_clip_traces()
-# test_common_reference()
-# test_norm_by_quantile()
-# test_notch_filter()
-# test_rectify()
-# test_remove_artifacts()
-# test_remove_bad_channels()
-# test_resample()
-# test_transform_traces()
-# test_whiten()
+if __name__ == '__main__':
+    # test_bandpass_filter()
+    # test_bandpass_filter_with_cache()
+    # test_blank_saturation()
+    # test_clip_traces()
+    # test_common_reference()
+    # test_norm_by_quantile()
+    # test_notch_filter()
+    # test_rectify()
+    # test_remove_artifacts()
+    # test_remove_bad_channels()
+    # test_resample()
+    test_transform_traces()
+    # test_whiten()


### PR DESCRIPTION
- For standardization, `transform_traces` and `clip_traces` are renamed `transform` and `clip`.

- Added a preprocessor to `center` the recordings by removing the mean channel-wise

- the filters fail if the dtype is `uint`. Added a check that transforms the data to `int` in that case by removing the appropriate offset