### PR TITLE
Simplify validation and curation argument passing using kwargs

### DIFF
--- a/spiketoolkit/curation/__init__.py
+++ b/spiketoolkit/curation/__init__.py
@@ -10,3 +10,4 @@ from .threshold_metrics import threshold_isolation_distances
 from .threshold_metrics import threshold_nn_metrics
 from .threshold_metrics import threshold_drift_metrics
 from .threshold_metrics import threshold_amplitude_cutoffs
+from ..validation import get_kwargs_params

--- a/spiketoolkit/curation/threshold_metrics.py
+++ b/spiketoolkit/curation/threshold_metrics.py
@@ -11,8 +11,7 @@ from spiketoolkit.validation.quality_metric_classes.snr import SNR
 from spiketoolkit.validation.quality_metric_classes.isolation_distance import IsolationDistance
 from spiketoolkit.validation.quality_metric_classes.nearest_neighbor import NearestNeighbor
 from spiketoolkit.validation.quality_metric_classes.drift_metric import DriftMetric
-from spiketoolkit.validation.quality_metric_classes.parameter_dictionaries import get_recording_params, \
-    get_amplitude_params, get_pca_scores_params, get_feature_params, update_param_dicts
+from spiketoolkit.validation.quality_metric_classes.parameter_dictionaries import update_param_dicts_with_kwargs
 
 
 def threshold_num_spikes(
@@ -47,7 +46,6 @@ def threshold_num_spikes(
     ----------
     threshold sorting extractor
     """
-
     md = MetricData(
         sorting=sorting,
         sampling_frequency=sampling_frequency,
@@ -227,12 +225,10 @@ def threshold_amplitude_cutoffs(
         recording,
         threshold,
         threshold_sign,
-        recording_params=get_recording_params(),
-        amplitude_params=get_amplitude_params(),
-        feature_params=get_feature_params(),
         save_as_property=True,
         seed=AmplitudeCutoff.params['seed'],
-        verbose=AmplitudeCutoff.params['verbose']
+        verbose=AmplitudeCutoff.params['verbose'],
+        **kwargs
 ):
     """
     Computes and thresholds the amplitude cutoffs in the sorted dataset with the given sign and value.
@@ -250,8 +246,14 @@ def threshold_amplitude_cutoffs(
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold.
         If 'greater', will threshold any metric greater than the given threshold.
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold.
-    amplitude_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
             amp_method: str
                 If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
                 If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
@@ -261,35 +263,23 @@ def threshold_amplitude_cutoffs(
                 Frames before peak to compute amplitude.
             amp_frames_after: int
                 Frames after peak to compute amplitude.
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
             apply_filter: bool
                 If True, recording is bandpass-filtered.
             freq_min: float
                 High-pass frequency for optional filter (default 300 Hz).
             freq_max: float
                 Low-pass frequency for optional filter (default 6000 Hz).
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save features in the sorting extractor.
             recompute_info: bool
                     If True, waveforms are recomputed
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-    seed: int
-        Random seed for reproducibility
-    verbose: bool
-        If True, will be verbose in metric computation.
     Returns
     ----------
     threshold sorting extractor
     """
-    rp_dict, ap_dict, fp_dict = update_param_dicts(recording_params=recording_params,
-                                                   amplitude_params=amplitude_params,
-                                                   feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(
         sorting=sorting,
@@ -328,11 +318,10 @@ def threshold_snrs(
         max_spikes_per_unit_for_snr=SNR.params['max_spikes_per_unit_for_snr'],
         template_mode=SNR.params['template_mode'],
         max_channel_peak=SNR.params['max_channel_peak'],
-        recording_params=get_recording_params(),
-        feature_params=get_feature_params(),
         save_as_property=True,
         seed=SNR.params['seed'],
-        verbose=SNR.params['verbose']
+        verbose=SNR.params['verbose'],
+        **kwargs
 ):
     """
     Computes and thresholds the snrs in the sorted dataset with the given sign and value.
@@ -341,45 +330,50 @@ def threshold_snrs(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor
-
     threshold: int or float
         The threshold for the given metric.
-
     threshold_sign: str
         If 'less', will threshold any metric less than the given threshold.
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold.
         If 'greater', will threshold any metric greater than the given threshold.
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold.
-
     snr_mode: str
             Mode to compute noise SNR ('mad' | 'std' - default 'mad')
-            
     snr_noise_duration: float
         Number of seconds to compute noise level from (default 10.0)
-
     max_spikes_per_unit_for_snr: int
         Maximum number of spikes to compute templates from (default 1000)
-
     template_mode: str
         Use 'mean' or 'median' to compute templates
-
     max_channel_peak: str
         If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
+    recompute_info: bool
+            If True, waveforms are recomputed
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            amp_method: str
+                If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
+                If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
+            amp_peak: str
+                If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
+            amp_frames_before: int
+                Frames before peak to compute amplitude.
+            amp_frames_after: int
+                Frames after peak to compute amplitude.
             apply_filter: bool
                 If True, recording is bandpass-filtered.
             freq_min: float
                 High-pass frequency for optional filter (default 300 Hz).
             freq_max: float
                 Low-pass frequency for optional filter (default 6000 Hz).
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save features in the sorting extractor.
             recompute_info: bool
@@ -387,24 +381,12 @@ def threshold_snrs(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    recompute_info: bool
-            If True, waveforms are recomputed
-
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
     Returns
     ----------
     threshold sorting extractor
     """
-    rp_dict, fp_dict = update_param_dicts(recording_params=recording_params,
-                                          feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
+
     md = MetricData(
         sorting=sorting,
         sampling_frequency=recording.get_sampling_frequency(),
@@ -432,12 +414,10 @@ def threshold_silhouette_scores(
         threshold,
         threshold_sign,
         max_spikes_for_silhouette=SilhouetteScore.params['max_spikes_for_silhouette'],
-        recording_params=get_recording_params(),
-        pca_scores_params=get_pca_scores_params(),
-        feature_params=get_feature_params(),
         save_as_property=True,
         seed=SilhouetteScore.params['seed'],
-        verbose=SilhouetteScore.params['verbose']
+        verbose=SilhouetteScore.params['verbose'],
+        **kwargs
 ):
     """
     Computes and thresholds the silhouette scores in the sorted dataset with the given sign and value.
@@ -446,72 +426,51 @@ def threshold_silhouette_scores(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor
-
     threshold: int or float
         The threshold for the given metric.
-
     threshold_sign: str
         If 'less', will threshold any metric less than the given threshold.
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold.
         If 'greater', will threshold any metric greater than the given threshold.
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold.
-
     max_spikes_for_silhouette: int
         Max spikes to be used for silhouette metric.
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            amp_method: str
+                If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
+                If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
+            amp_peak: str
+                If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
+            amp_frames_before: int
+                Frames before peak to compute amplitude.
+            amp_frames_after: int
+                Frames after peak to compute amplitude.
             apply_filter: bool
                 If True, recording is bandpass-filtered.
             freq_min: float
                 High-pass frequency for optional filter (default 300 Hz).
             freq_max: float
                 Low-pass frequency for optional filter (default 6000 Hz).
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
-            ms_before: float
-                Time period in ms to cut waveforms before the spike events
-            ms_after: float
-                Time period in ms to cut waveforms after the spike events
-            dtype: dtype
-                The numpy dtype of the waveforms
-            max_spikes_per_unit: int
-                The maximum number of spikes to extract per unit.
-            max_spikes_for_pca: int
-                The maximum number of spikes to use to compute PCA.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save features in the sorting extractor.
             recompute_info: bool
                     If True, waveforms are recomputed
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
-
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-    
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
     Returns
     ----------
     threshold sorting extractor
     """
-    rp_dict, ps_dict, fp_dict = update_param_dicts(recording_params=recording_params,
-                                                   pca_scores_params=pca_scores_params,
-                                                   feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(
         sorting=sorting,
@@ -527,12 +486,12 @@ def threshold_silhouette_scores(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         save_features_props=fp_dict['save_features_props'],
         recompute_info=fp_dict['recompute_info'],
         seed=seed,
@@ -551,12 +510,10 @@ def threshold_d_primes(
         threshold_sign,
         num_channels_to_compare=DPrime.params['num_channels_to_compare'],
         max_spikes_per_cluster=DPrime.params['max_spikes_per_cluster'],
-        recording_params=get_recording_params(),
-        pca_scores_params=get_pca_scores_params(),
-        feature_params=get_feature_params(),
         save_as_property=True,
         seed=DPrime.params['seed'],
-        verbose=DPrime.params['verbose']
+        verbose=DPrime.params['verbose'],
+        **kwargs
 ):
     """
     Computes and thresholds the d primes in the sorted dataset with the given sign and value.
@@ -565,49 +522,42 @@ def threshold_d_primes(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor
-
     threshold: int or float
         The threshold for the given metric.
-
     threshold_sign: str
         If 'less', will threshold any metric less than the given threshold.
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold.
         If 'greater', will threshold any metric greater than the given threshold.
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold.
-
     num_channels_to_compare: int
         The number of channels to be used for the PC extraction and comparison
-        
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            amp_method: str
+                If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
+                If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
+            amp_peak: str
+                If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
+            amp_frames_before: int
+                Frames before peak to compute amplitude.
+            amp_frames_after: int
+                Frames after peak to compute amplitude.
             apply_filter: bool
                 If True, recording is bandpass-filtered.
             freq_min: float
                 High-pass frequency for optional filter (default 300 Hz).
             freq_max: float
                 Low-pass frequency for optional filter (default 6000 Hz).
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
-            ms_before: float
-                Time period in ms to cut waveforms before the spike events
-            ms_after: float
-                Time period in ms to cut waveforms after the spike events
-            dtype: dtype
-                The numpy dtype of the waveforms
-            max_spikes_per_unit: int
-                The maximum number of spikes to extract per unit.
-            max_spikes_for_pca: int
-                The maximum number of spikes to use to compute PCA.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save features in the sorting extractor.
             recompute_info: bool
@@ -615,25 +565,11 @@ def threshold_d_primes(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-    
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-    
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
     Returns
     ----------
     threshold sorting extractor
     """
-    rp_dict, ps_dict, fp_dict = update_param_dicts(recording_params=recording_params,
-                                                   pca_scores_params=pca_scores_params,
-                                                   feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(
         sorting=sorting,
@@ -649,12 +585,12 @@ def threshold_d_primes(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         save_features_props=fp_dict['save_features_props'],
         recompute_info=fp_dict['recompute_info'],
         seed=seed,
@@ -673,12 +609,10 @@ def threshold_l_ratios(
         threshold_sign,
         num_channels_to_compare=LRatio.params['num_channels_to_compare'],
         max_spikes_per_cluster=LRatio.params['max_spikes_per_cluster'],
-        recording_params=get_recording_params(),
-        pca_scores_params=get_pca_scores_params(),
-        feature_params=get_feature_params(),
         save_as_property=True,
         seed=LRatio.params['seed'],
-        verbose=LRatio.params['verbose']
+        verbose=LRatio.params['verbose'],
+        **kwargs
 ):
     """
     Computes and thresholds the l ratios in the sorted dataset with the given sign and value.
@@ -687,49 +621,42 @@ def threshold_l_ratios(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor
-
     threshold: int or float
         The threshold for the given metric.
-
     threshold_sign: str
         If 'less', will threshold any metric less than the given threshold.
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold.
         If 'greater', will threshold any metric greater than the given threshold.
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold.
-
     num_channels_to_compare: int
         The number of channels to be used for the PC extraction and comparison
-        
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            amp_method: str
+                If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
+                If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
+            amp_peak: str
+                If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
+            amp_frames_before: int
+                Frames before peak to compute amplitude.
+            amp_frames_after: int
+                Frames after peak to compute amplitude.
             apply_filter: bool
                 If True, recording is bandpass-filtered.
             freq_min: float
                 High-pass frequency for optional filter (default 300 Hz).
             freq_max: float
                 Low-pass frequency for optional filter (default 6000 Hz).
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
-            ms_before: float
-                Time period in ms to cut waveforms before the spike events
-            ms_after: float
-                Time period in ms to cut waveforms after the spike events
-            dtype: dtype
-                The numpy dtype of the waveforms
-            max_spikes_per_unit: int
-                The maximum number of spikes to extract per unit.
-            max_spikes_for_pca: int
-                The maximum number of spikes to use to compute PCA.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save features in the sorting extractor.
             recompute_info: bool
@@ -737,25 +664,11 @@ def threshold_l_ratios(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-    
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-    
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
     Returns
     ----------
     threshold sorting extractor
     """
-    rp_dict, ps_dict, fp_dict = update_param_dicts(recording_params=recording_params,
-                                                   pca_scores_params=pca_scores_params,
-                                                   feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(
         sorting=sorting,
@@ -771,12 +684,12 @@ def threshold_l_ratios(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         save_features_props=fp_dict['save_features_props'],
         recompute_info=fp_dict['recompute_info'],
         seed=seed,
@@ -795,12 +708,10 @@ def threshold_isolation_distances(
         threshold_sign,
         num_channels_to_compare=IsolationDistance.params['num_channels_to_compare'],
         max_spikes_per_cluster=IsolationDistance.params['max_spikes_per_cluster'],
-        recording_params=get_recording_params(),
-        pca_scores_params=get_pca_scores_params(),
-        feature_params=get_feature_params(),
         save_as_property=True,
         seed=IsolationDistance.params['seed'],
-        verbose=IsolationDistance.params['verbose']
+        verbose=IsolationDistance.params['verbose'],
+        **kwargs
 ):
     """
     Computes and thresholds the isolation distances in the sorted dataset with the given sign and value.
@@ -809,49 +720,42 @@ def threshold_isolation_distances(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor
-
     threshold: int or float
         The threshold for the given metric.
-
     threshold_sign: str
         If 'less', will threshold any metric less than the given threshold.
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold.
         If 'greater', will threshold any metric greater than the given threshold.
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold.
-
     num_channels_to_compare: int
         The number of channels to be used for the PC extraction and comparison
-        
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            amp_method: str
+                If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
+                If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
+            amp_peak: str
+                If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
+            amp_frames_before: int
+                Frames before peak to compute amplitude.
+            amp_frames_after: int
+                Frames after peak to compute amplitude.
             apply_filter: bool
                 If True, recording is bandpass-filtered.
             freq_min: float
                 High-pass frequency for optional filter (default 300 Hz).
             freq_max: float
                 Low-pass frequency for optional filter (default 6000 Hz).
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
-            ms_before: float
-                Time period in ms to cut waveforms before the spike events
-            ms_after: float
-                Time period in ms to cut waveforms after the spike events
-            dtype: dtype
-                The numpy dtype of the waveforms
-            max_spikes_per_unit: int
-                The maximum number of spikes to extract per unit.
-            max_spikes_for_pca: int
-                The maximum number of spikes to use to compute PCA.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save features in the sorting extractor.
             recompute_info: bool
@@ -859,25 +763,11 @@ def threshold_isolation_distances(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-    
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
     Returns
     ----------
     threshold sorting extractor
     """
-    rp_dict, ps_dict, fp_dict = update_param_dicts(recording_params=recording_params,
-                                                   pca_scores_params=pca_scores_params,
-                                                   feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(
         sorting=sorting,
@@ -893,12 +783,12 @@ def threshold_isolation_distances(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         save_features_props=fp_dict['save_features_props'],
         recompute_info=fp_dict['recompute_info'],
         seed=seed,
@@ -920,12 +810,10 @@ def threshold_nn_metrics(
         max_spikes_per_cluster=NearestNeighbor.params['max_spikes_per_cluster'],
         max_spikes_for_nn=NearestNeighbor.params['max_spikes_for_nn'],
         n_neighbors=NearestNeighbor.params['n_neighbors'],
-        recording_params=get_recording_params(),
-        pca_scores_params=get_pca_scores_params(),
-        feature_params=get_feature_params(),
         save_as_property=True,
         seed=NearestNeighbor.params['seed'],
-        verbose=NearestNeighbor.params['verbose']
+        verbose=NearestNeighbor.params['verbose'],
+        **kwargs
 ):
     """
     Computes and thresholds the specified nearest neighbor metric for the sorted dataset with the given sign and value.
@@ -934,58 +822,48 @@ def threshold_nn_metrics(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor
-
     threshold: int or float
         The threshold for the given metric.
-
     threshold_sign: str
         If 'less', will threshold any metric less than the given threshold.
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold.
         If 'greater', will threshold any metric greater than the given threshold.
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold.
-
     metric_name: str
         The name of the nearest neighbor metric to be thresholded (either "nn_hit_rate" or "nn_miss_rate").
-
     num_channels_to_compare: int
         The number of channels to be used for the PC extraction and comparison
-        
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-
     max_spikes_for_nn: int
         Max spikes to be used for nearest-neighbors calculation.
-    
     n_neighbors: int
         Number of neighbors to compare.
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            amp_method: str
+                If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
+                If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
+            amp_peak: str
+                If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
+            amp_frames_before: int
+                Frames before peak to compute amplitude.
+            amp_frames_after: int
+                Frames after peak to compute amplitude.
             apply_filter: bool
                 If True, recording is bandpass-filtered.
             freq_min: float
                 High-pass frequency for optional filter (default 300 Hz).
             freq_max: float
                 Low-pass frequency for optional filter (default 6000 Hz).
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
-            ms_before: float
-                Time period in ms to cut waveforms before the spike events
-            ms_after: float
-                Time period in ms to cut waveforms after the spike events
-            dtype: dtype
-                The numpy dtype of the waveforms
-            max_spikes_per_unit: int
-                The maximum number of spikes to extract per unit.
-            max_spikes_for_pca: int
-                The maximum number of spikes to use to compute PCA.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save features in the sorting extractor.
             recompute_info: bool
@@ -993,25 +871,11 @@ def threshold_nn_metrics(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-    
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-        
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
     Returns
     ----------
     threshold sorting extractor
     """
-    rp_dict, ps_dict, fp_dict = update_param_dicts(recording_params=recording_params,
-                                                   pca_scores_params=pca_scores_params,
-                                                   feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(
         sorting=sorting,
@@ -1026,12 +890,12 @@ def threshold_nn_metrics(
         verbose=verbose
     )
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         save_features_props=fp_dict['save_features_props'],
         recompute_info=fp_dict['recompute_info'],
         seed=seed,
@@ -1052,12 +916,10 @@ def threshold_drift_metrics(
         metric_name="max_drift",
         drift_metrics_interval_s=DriftMetric.params['drift_metrics_interval_s'],
         drift_metrics_min_spikes_per_interval=DriftMetric.params['drift_metrics_min_spikes_per_interval'],
-        recording_params=get_recording_params(),
-        pca_scores_params=get_pca_scores_params(),
-        feature_params=get_feature_params(),
         save_as_property=True,
         seed=DriftMetric.params['seed'],
-        verbose=DriftMetric.params['verbose']
+        verbose=DriftMetric.params['verbose'],
+        **kwargs
 ):
     """
     Computes and thresholds the specified drift metric for the sorted dataset with the given sign and value.
@@ -1066,52 +928,44 @@ def threshold_drift_metrics(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor
-
     threshold: int or float
         The threshold for the given metric.
-
     threshold_sign: str
         If 'less', will threshold any metric less than the given threshold.
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold.
         If 'greater', will threshold any metric greater than the given threshold.
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold.
-
     metric_name: str
         The name of the nearest neighbor metric to be thresholded (either "max_drift" or "cumulative_drift").
-
     drift_metrics_interval_s: float
         Time period for evaluating drift.
-
     drift_metrics_min_spikes_per_interval: int
         Minimum number of spikes for evaluating drift metrics per interval.
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            amp_method: str
+                If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
+                If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
+            amp_peak: str
+                If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
+            amp_frames_before: int
+                Frames before peak to compute amplitude.
+            amp_frames_after: int
+                Frames after peak to compute amplitude.
             apply_filter: bool
                 If True, recording is bandpass-filtered.
             freq_min: float
                 High-pass frequency for optional filter (default 300 Hz).
             freq_max: float
                 Low-pass frequency for optional filter (default 6000 Hz).
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
-            ms_before: float
-                Time period in ms to cut waveforms before the spike events
-            ms_after: float
-                Time period in ms to cut waveforms after the spike events
-            dtype: dtype
-                The numpy dtype of the waveforms
-            max_spikes_per_unit: int
-                The maximum number of spikes to extract per unit.
-            max_spikes_for_pca: int
-                The maximum number of spikes to use to compute PCA.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save features in the sorting extractor.
             recompute_info: bool
@@ -1119,22 +973,11 @@ def threshold_drift_metrics(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-    
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
     Returns
     ----------
     threshold sorting extractor
     """
-    rp_dict, ps_dict, fp_dict = update_param_dicts(recording_params=recording_params,
-                                                   pca_scores_params=pca_scores_params,
-                                                   feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(
         sorting=sorting,
@@ -1150,12 +993,12 @@ def threshold_drift_metrics(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         save_features_props=fp_dict['save_features_props'],
         recompute_info=fp_dict['recompute_info'],
         seed=seed,

--- a/spiketoolkit/tests/test_curation.py
+++ b/spiketoolkit/tests/test_curation.py
@@ -14,6 +14,7 @@ from spiketoolkit.curation import (
     threshold_isolation_distances,
     threshold_nn_metrics,
     threshold_drift_metrics,
+    get_kwargs_params
 )
 
 
@@ -117,6 +118,9 @@ def test_thresh_frs():
 
     assert np.all(new_fr >= fr_thresh)
     check_dumping(sort_fr)
+
+def test_kwarg_params():
+    print(get_kwargs_params())
 
 
 if __name__ == "__main__":

--- a/spiketoolkit/tests/test_curation.py
+++ b/spiketoolkit/tests/test_curation.py
@@ -33,7 +33,7 @@ from spiketoolkit.validation import (
     compute_metrics,
 )
 
-from .utils import check_dumping, create_dumpable_sorting, create_dumpable_extractors
+from spiketoolkit.tests.utils import check_dumping, create_dumpable_sorting, create_dumpable_extractors
 
 
 def test_thresh_num_spikes():
@@ -64,10 +64,8 @@ def test_thresh_silhouettes():
 
     silhouette_thresh = .5
 
-    sort_silhouette = threshold_silhouette_scores(
-        sort, rec, silhouette_thresh, "less"
-    )
-    silhouette = np.asarray(compute_silhouette_scores(sort, rec)[0])
+    sort_silhouette = threshold_silhouette_scores(sort, rec, silhouette_thresh, "less", apply_filter=False)
+    silhouette = np.asarray(compute_silhouette_scores(sort, rec, apply_filter=False)[0])
     new_silhouette = silhouette[np.where(silhouette >= silhouette_thresh)]
 
     assert np.all(new_silhouette >= silhouette_thresh)
@@ -79,9 +77,7 @@ def test_thresh_d_primes():
 
     d_primes_thresh = .5
 
-    sort_d_primes = threshold_d_primes(
-        sort, rec, d_primes_thresh, "less"
-    )
+    sort_d_primes = threshold_d_primes(sort, rec, d_primes_thresh, "less", apply_filter=False)
     new_d_primes = compute_d_primes(sort_d_primes, rec)[0]
 
     assert np.all(new_d_primes >= d_primes_thresh)
@@ -93,9 +89,7 @@ def test_thresh_l_ratios():
 
     l_ratios_thresh = 0
 
-    sort_l_ratios = threshold_l_ratios(
-        sort, rec, l_ratios_thresh, "less"
-    )
+    sort_l_ratios = threshold_l_ratios(sort, rec, l_ratios_thresh, "less", apply_filter=False)
     new_l_ratios = compute_l_ratios(sort_l_ratios, rec)[0]
 
     assert np.all(new_l_ratios >= l_ratios_thresh)
@@ -107,13 +101,12 @@ def test_thresh_amplitude_cutoffs():
 
     amplitude_cutoff_thresh = 0
 
-    sort_amplitude_cutoff = threshold_amplitude_cutoffs(
-        sort, rec, amplitude_cutoff_thresh, "less"
-    )
+    sort_amplitude_cutoff = threshold_amplitude_cutoffs(sort, rec, amplitude_cutoff_thresh, "less", apply_filter=False)
     new_amplitude_cutoff = compute_amplitude_cutoffs(sort_amplitude_cutoff, rec)[0]
 
     assert np.all(new_amplitude_cutoff >= amplitude_cutoff_thresh)
     check_dumping(sort_amplitude_cutoff)
+
 
 def test_thresh_frs():
     sort = create_dumpable_sorting(duration=10, num_channels=4, K=10, seed=0, folder='test')
@@ -128,8 +121,10 @@ def test_thresh_frs():
 
 if __name__ == "__main__":
     test_thresh_silhouettes()
-    test_thresh_snrs()
-    test_thresh_frs()
-    test_thresh_amplitude_cutoffs()
-    test_thresh_silhouettes()
-    test_thresh_l_ratios()
+    # test_thresh_snrs()
+    # test_thresh_frs()
+    # test_thresh_amplitude_cutoffs()
+    # test_thresh_silhouettes()
+    # test_thresh_l_ratios()
+    # test_thresh_snrs()
+    # test_thresh_num_spikes()

--- a/spiketoolkit/tests/test_validation.py
+++ b/spiketoolkit/tests/test_validation.py
@@ -2,7 +2,8 @@ import spikeextractors as se
 from numpy.testing import assert_array_equal
 from spiketoolkit.validation import compute_isolation_distances, compute_isi_violations, compute_snrs, \
     compute_amplitude_cutoffs, compute_d_primes, compute_drift_metrics, compute_firing_rates, compute_l_ratios, \
-    compute_metrics, compute_nn_metrics, compute_num_spikes, compute_presence_ratios, compute_silhouette_scores \
+    compute_metrics, compute_nn_metrics, compute_num_spikes, compute_presence_ratios, compute_silhouette_scores, \
+    get_kwargs_params
 
 
 def test_functions():
@@ -23,6 +24,10 @@ def test_functions():
     nn_hit, nn_miss = compute_nn_metrics(sort, rec)[0]
 
     snr = compute_snrs(sort, rec)
+
+
+def test_kwarg_params():
+    print(get_kwargs_params())
 
 
 if __name__ == '__main__':

--- a/spiketoolkit/tests/test_validation.py
+++ b/spiketoolkit/tests/test_validation.py
@@ -4,6 +4,7 @@ from spiketoolkit.validation import compute_isolation_distances, compute_isi_vio
     compute_amplitude_cutoffs, compute_d_primes, compute_drift_metrics, compute_firing_rates, compute_l_ratios, \
     compute_metrics, compute_nn_metrics, compute_num_spikes, compute_presence_ratios, compute_silhouette_scores \
 
+
 def test_functions():
     rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4, seed=0)
 
@@ -12,7 +13,7 @@ def test_functions():
     isi = compute_isi_violations(sort)
     presence = compute_presence_ratios(sort)
 
-    amp_cutoff = compute_amplitude_cutoffs(sort, rec)
+    amp_cutoff = compute_amplitude_cutoffs(sort, rec, apply_filter=False)
 
     max_drift, cum_drift = compute_drift_metrics(sort, rec)[0]
     silh = compute_silhouette_scores(sort, rec)
@@ -22,3 +23,7 @@ def test_functions():
     nn_hit, nn_miss = compute_nn_metrics(sort, rec)[0]
 
     snr = compute_snrs(sort, rec)
+
+
+if __name__ == '__main__':
+    test_functions()

--- a/spiketoolkit/validation/quality_metric_classes/metric_data.py
+++ b/spiketoolkit/validation/quality_metric_classes/metric_data.py
@@ -3,6 +3,7 @@ from collections import OrderedDict, defaultdict
 
 import numpy as np
 import pandas as pd
+from copy import deepcopy
 from spikeextractors import RecordingExtractor, SortingExtractor
 
 import spikemetrics.metrics as metrics
@@ -89,7 +90,7 @@ class MetricData:
         assert isinstance(
             sorting, SortingExtractor
         ), "'sorting' must be  a SortingExtractor object"
-        self._sorting = sorting
+        self._sorting = deepcopy(sorting)
         self._set_unit_ids(unit_ids)
         self._set_epochs(epoch_tuples, epoch_names)
         self._spike_times = spike_times

--- a/spiketoolkit/validation/quality_metric_classes/parameter_dictionaries.py
+++ b/spiketoolkit/validation/quality_metric_classes/parameter_dictionaries.py
@@ -130,19 +130,19 @@ def update_param_dicts_with_kwargs(kwargs):
         for k in kwargs.keys():
             if k in recording_params.keys():
                 recording_params[k] = kwargs[k]
-    if np.any([k in amplitude_params.keys() for k in kwargs.keys()]):
+    elif np.any([k in amplitude_params.keys() for k in kwargs.keys()]):
         for k in kwargs.keys():
             if k in amplitude_params.keys():
                 amplitude_params[k] = kwargs[k]
-    if np.any([k in pca_scores_params.keys() for k in kwargs.keys()]):
+    elif np.any([k in pca_scores_params.keys() for k in kwargs.keys()]):
         for k in kwargs.keys():
             if k in pca_scores_params.keys():
                 pca_scores_params[k] = kwargs[k]
-    if np.any([k in epoch_params.keys() for k in kwargs.keys()]):
+    elif np.any([k in epoch_params.keys() for k in kwargs.keys()]):
         for k in kwargs.keys():
             if k in epoch_params.keys():
                 epoch_params[k] = kwargs[k]
-    if np.any([k in feature_params.keys()for k in kwargs.keys()]):
+    elif np.any([k in feature_params.keys()for k in kwargs.keys()]):
         for k in kwargs.keys():
             if k in feature_params.keys():
                 feature_params[k] = kwargs[k]

--- a/spiketoolkit/validation/quality_metric_classes/parameter_dictionaries.py
+++ b/spiketoolkit/validation/quality_metric_classes/parameter_dictionaries.py
@@ -1,122 +1,150 @@
-
 from collections import OrderedDict
+import numpy as np
 
-recording_params_dict = OrderedDict([('apply_filter', True), ('freq_min',300.0), ('freq_max',6000.0)])
-#Defining GUI Params
+recording_params_dict = OrderedDict([('apply_filter', True), ('freq_min', 300.0), ('freq_max', 6000.0)])
+# Defining GUI Params
 keys = list(recording_params_dict.keys())
 types = [type(recording_params_dict[key]) for key in keys]
 values = [recording_params_dict[key] for key in keys]
-recording_gui_params = [{'name': keys[0], 'type': str(types[0].__name__), 'value': values[0], 'default': values[0], 'title': "If True, apply filter"},
-                        {'name': keys[1], 'type': str(types[1].__name__), 'value': values[1], 'default': values[1], 'title': "High-pass frequency"},
-                        {'name': keys[2], 'type': str(types[2].__name__), 'value': values[2], 'default': values[2], 'title': "Low-pass frequency"}]
+recording_gui_params = [{'name': keys[0], 'type': str(types[0].__name__), 'value': values[0], 'default': values[0],
+                         'title': "If True, apply filter"},
+                        {'name': keys[1], 'type': str(types[1].__name__), 'value': values[1], 'default': values[1],
+                         'title': "High-pass frequency"},
+                        {'name': keys[2], 'type': str(types[2].__name__), 'value': values[2], 'default': values[2],
+                         'title': "Low-pass frequency"}]
 
-feature_params_dict = OrderedDict([('max_spikes_per_unit',300), ('recompute_info',False), ('save_features_props',True)])
-#Defining GUI Params
+feature_params_dict = OrderedDict(
+    [('max_spikes_per_unit', 300), ('recompute_info', False), ('save_features_props', True)])
+# Defining GUI Params
 keys = list(feature_params_dict.keys())
 types = [type(feature_params_dict[key]) for key in keys]
 values = [feature_params_dict[key] for key in keys]
-feature_gui_params = [{'name': keys[0], 'type': str(types[0].__name__), 'value': values[0], 'default': values[0], 'title': "The maximum number of spikes to extract per unit to compute features."},
-                      {'name': keys[1], 'type': str(types[1].__name__), 'value': values[1], 'default': values[1], 'title': "If True, will always re-extract waveforms."},
-                      {'name': keys[2], 'type': str(types[2].__name__), 'value': values[2], 'default': values[2], 'title': "If true, it will save the features in the sorting extractor."}]
-                      
-amplitude_params_dict =  OrderedDict([('amp_method',"absolute"), ('amp_peak',"both"),  ('amp_frames_before',3), ('amp_frames_after',3)])
-#Defining GUI Params
+feature_gui_params = [{'name': keys[0], 'type': str(types[0].__name__), 'value': values[0], 'default': values[0],
+                       'title': "The maximum number of spikes to extract per unit to compute features."},
+                      {'name': keys[1], 'type': str(types[1].__name__), 'value': values[1], 'default': values[1],
+                       'title': "If True, will always re-extract waveforms."},
+                      {'name': keys[2], 'type': str(types[2].__name__), 'value': values[2], 'default': values[2],
+                       'title': "If true, it will save the features in the sorting extractor."}]
+
+amplitude_params_dict = OrderedDict(
+    [('amp_method', "absolute"), ('amp_peak', "both"), ('amp_frames_before', 3), ('amp_frames_after', 3)])
+# Defining GUI Params
 keys = list(amplitude_params_dict.keys())
 types = [type(amplitude_params_dict[key]) for key in keys]
 values = [amplitude_params_dict[key] for key in keys]
-amplitude_gui_params = [{'name': keys[0], 'type': str(types[0].__name__), 'value': values[0], 'default': values[0], 'title': "If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned. If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes."},
-                        {'name': keys[1], 'type': str(types[1].__name__), 'value': values[1], 'default': values[1], 'title': "If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)"},
-                        {'name': keys[2], 'type': str(types[2].__name__), 'value': values[2], 'default': values[2], 'title': "Frames before peak to compute amplitude"},
-                        {'name': keys[3], 'type': str(types[3].__name__), 'value': values[3], 'default': values[3], 'title': "Frames after peak to compute amplitude"}]
+amplitude_gui_params = [{'name': keys[0], 'type': str(types[0].__name__), 'value': values[0], 'default': values[0],
+                         'title': "If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned. "
+                                  "If 'relative', amplitudes are returned as ratios between waveform amplitudes and "
+                                  "template amplitudes."},
+                        {'name': keys[1], 'type': str(types[1].__name__), 'value': values[1], 'default': values[1],
+                         'title': "If maximum channel has to be found among negative peaks ('neg'), positive ('pos') "
+                                  "or both ('both' - default)"},
+                        {'name': keys[2], 'type': str(types[2].__name__), 'value': values[2], 'default': values[2],
+                         'title': "Frames before peak to compute amplitude"},
+                        {'name': keys[3], 'type': str(types[3].__name__), 'value': values[3], 'default': values[3],
+                         'title': "Frames after peak to compute amplitude"}]
 
-pca_scores_params_dict = OrderedDict([('n_comp',3), ('ms_before',1.0), ('ms_after',2.0), ('dtype',None), ('max_spikes_for_pca',100000)])
-#Defining GUI Params                         
+pca_scores_params_dict = OrderedDict(
+    [('n_comp', 3), ('ms_before', 1.0), ('ms_after', 2.0), ('dtype', None), ('max_spikes_for_pca', 100000)])
+# Defining GUI Params
 keys = list(pca_scores_params_dict.keys())
 types = [type(pca_scores_params_dict[key]) for key in keys]
 values = [pca_scores_params_dict[key] for key in keys]
-pca_scores_gui_params = [{'name': keys[0], 'type': str(types[0].__name__), 'value': values[0], 'default': values[0], 'title': "n_compFeatures in template-gui format"},
-                         {'name': keys[1], 'type': str(types[1].__name__), 'value': values[1], 'default': values[1], 'title': "Time period in ms to cut waveforms before the spike events"},
-                         {'name': keys[2], 'type': str(types[2].__name__), 'value': values[2], 'default': values[2], 'title': "Time period in ms to cut waveforms after the spike events"},
-                         {'name': keys[3], 'type': 'dtype', 'value': values[3], 'default': values[3], 'title': "The numpy dtype of the waveforms"},
-                         {'name': keys[4], 'type': str(types[4].__name__), 'value': values[4], 'default': values[4], 'title': "The maximum number of spikes to use to compute PCA."}]
+pca_scores_gui_params = [{'name': keys[0], 'type': str(types[0].__name__), 'value': values[0], 'default': values[0],
+                          'title': "n_compFeatures in template-gui format"},
+                         {'name': keys[1], 'type': str(types[1].__name__), 'value': values[1], 'default': values[1],
+                          'title': "Time period in ms to cut waveforms before the spike events"},
+                         {'name': keys[2], 'type': str(types[2].__name__), 'value': values[2], 'default': values[2],
+                          'title': "Time period in ms to cut waveforms after the spike events"},
+                         {'name': keys[3], 'type': 'dtype', 'value': values[3], 'default': values[3],
+                          'title': "The numpy dtype of the waveforms"},
+                         {'name': keys[4], 'type': str(types[4].__name__), 'value': values[4], 'default': values[4],
+                          'title': "The maximum number of spikes to use to compute PCA."}]
 
-epoch_params_dict =OrderedDict([('epoch_tuples',None), ('epoch_names',None)])
+epoch_params_dict = OrderedDict([('epoch_tuples', None), ('epoch_names', None)])
+
 
 def get_recording_params():
     return recording_params_dict.copy()
 
+
 def get_amplitude_params():
     return amplitude_params_dict.copy()
+
 
 def get_pca_scores_params():
     return pca_scores_params_dict.copy()
 
+
 def get_epoch_params():
     return epoch_params_dict.copy()
+
 
 def get_feature_params():
     return feature_params_dict.copy()
 
+
 def get_recording_gui_params():
     return recording_gui_params.copy()
+
 
 def get_amplitude_gui_params():
     return amplitude_gui_params.copy()
 
+
 def get_pca_scores_gui_params():
     return pca_scores_gui_params.copy()
+
 
 def get_feature_gui_params():
     return feature_gui_params.copy()
 
-def update_param_dicts(recording_params=None, amplitude_params=None, 
-                       pca_scores_params=None, epoch_params=None,
-                       feature_params=None):
 
-    param_dicts = []
-    if recording_params is not None:
-        if not set(recording_params.keys()).issubset(
-            set(get_recording_params().keys())
-        ):
-            raise ValueError("Improper parameter entered into the recording param dict.")
-        else:
-            recording_params = OrderedDict(get_recording_params(), **recording_params)
-            param_dicts.append(recording_params)
+def get_kwargs_params():
+    '''
+    Returns all available keyword argument params
 
-    if amplitude_params is not None:
-        if not set(amplitude_params.keys()).issubset(
-            set(get_amplitude_params().keys())
-        ):
-            raise ValueError("Improper parameter entered into the amplitude param dict.")
-        else:
-            amplitude_params = OrderedDict(get_amplitude_params(), **amplitude_params)
-            param_dicts.append(amplitude_params)
+    Returns
+    -------
+    all_params: dict
+        Dictionary with all available keyword arguments for validation and curation functions.
+    '''
+    all_params = {}
+    all_params.update(get_recording_params())
+    all_params.update(get_amplitude_params())
+    all_params.update(get_pca_scores_params())
+    all_params.update(get_epoch_params())
+    all_params.update(get_feature_params())
 
-    if pca_scores_params is not None:
-        if not set(pca_scores_params.keys()).issubset(
-            set(get_pca_scores_params().keys())
-        ):
-            raise ValueError("Improper parameter entered into the amplitude param dict.")
-        else:
-            pca_scores_params = OrderedDict(get_pca_scores_params(), **pca_scores_params)
-            param_dicts.append(pca_scores_params)
+    return all_params
 
-    if epoch_params is not None:        
-        if not set(epoch_params.keys()).issubset(
-            set(get_epoch_params().keys())
-        ):
-            raise ValueError("Improper parameter entered into the epoch params dict")
-        else:
-            epoch_params = OrderedDict(get_epoch_params(), **epoch_params)
-            param_dicts.append(epoch_params)
 
-    if feature_params is not None:        
-        if not set(feature_params.keys()).issubset(
-            set(get_feature_params().keys())
-        ):
-            raise ValueError("Improper parameter entered into the feature param dict.")
-        else:
-            feature_params = OrderedDict(get_feature_params(), **feature_params)
-            param_dicts.append(feature_params)
+def update_param_dicts_with_kwargs(kwargs):
+    recording_params = get_recording_params()
+    amplitude_params = get_amplitude_params()
+    pca_scores_params = get_pca_scores_params()
+    epoch_params = get_epoch_params()
+    feature_params = get_feature_params()
 
-    return param_dicts
+    if np.any([k in recording_params.keys() for k in kwargs.keys()]):
+        for k in kwargs.keys():
+            if k in recording_params.keys():
+                recording_params[k] = kwargs[k]
+    if np.any([k in amplitude_params.keys() for k in kwargs.keys()]):
+        for k in kwargs.keys():
+            if k in amplitude_params.keys():
+                amplitude_params[k] = kwargs[k]
+    if np.any([k in pca_scores_params.keys() for k in kwargs.keys()]):
+        for k in kwargs.keys():
+            if k in pca_scores_params.keys():
+                pca_scores_params[k] = kwargs[k]
+    if np.any([k in epoch_params.keys() for k in kwargs.keys()]):
+        for k in kwargs.keys():
+            if k in epoch_params.keys():
+                epoch_params[k] = kwargs[k]
+    if np.any([k in feature_params.keys()for k in kwargs.keys()]):
+        for k in kwargs.keys():
+            if k in feature_params.keys():
+                feature_params[k] = kwargs[k]
+
+    return recording_params, amplitude_params, pca_scores_params, epoch_params, feature_params

--- a/spiketoolkit/validation/quality_metrics.py
+++ b/spiketoolkit/validation/quality_metrics.py
@@ -10,18 +10,22 @@ from .quality_metric_classes.isi_violation import ISIViolation
 from .quality_metric_classes.snr import SNR
 from .quality_metric_classes.isolation_distance import IsolationDistance
 from .quality_metric_classes.nearest_neighbor import NearestNeighbor
-from .quality_metric_classes.drift_metric import DriftMetric   
-from .quality_metric_classes.parameter_dictionaries import get_recording_params, get_amplitude_params, get_pca_scores_params, get_epoch_params, update_param_dicts, get_feature_params
+from .quality_metric_classes.drift_metric import DriftMetric
+from .quality_metric_classes.parameter_dictionaries import update_param_dicts_with_kwargs
 from collections import OrderedDict
+from copy import deepcopy
+
+
 # All parameter values are stored in the class definitions
 
+
 def compute_num_spikes(
-    sorting,
-    sampling_frequency=None,
-    epoch_params=get_epoch_params(),
-    save_as_property=True,
-    verbose=NumSpikes.params['verbose'],
-    unit_ids=None
+        sorting,
+        sampling_frequency=None,
+        save_as_property=True,
+        verbose=NumSpikes.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the num spikes for the sorted dataset.
@@ -32,24 +36,25 @@ def compute_num_spikes(
         The sorting result to be evaluated.
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor.
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs.
     save_as_property: bool
         If True, the metric is saved as sorting property
     verbose: bool
         If True, will be verbose in metric computation.
     unit_ids: list
         List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            epoch_tuples: list
+                A list of tuples with a start and end time for each epoch
+            epoch_names: list
+                A list of strings for the names of the given epochs.
+
     Returns
     ----------
     num_spikes_epochs: list of lists
         The num spikes of the sorted units in the given epochs.
     """
-    ep_dict, = update_param_dicts(epoch_params=epoch_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
@@ -73,12 +78,12 @@ def compute_num_spikes(
 
 
 def compute_firing_rates(
-    sorting,
-    sampling_frequency=None,
-    epoch_params=get_epoch_params(),
-    save_as_property=True,
-    verbose=FiringRate.params['verbose'],
-    unit_ids=None
+        sorting,
+        sampling_frequency=None,
+        save_as_property=True,
+        verbose=FiringRate.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the firing rates for the sorted dataset.
@@ -89,24 +94,25 @@ def compute_firing_rates(
         The sorting result to be evaluated.
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor.
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs.
     save_as_property: bool
         If True, the metric is saved as sorting property
     verbose: bool
         If True, will be verbose in metric computation.
     unit_ids: list
         List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            epoch_tuples: list
+                A list of tuples with a start and end time for each epoch
+            epoch_names: list
+                A list of strings for the names of the given epochs.
+
     Returns
     ----------
     firing_rate_epochs: list of lists
         The firing rates of the sorted units in the given epochs.
     """
-    ep_dict, = update_param_dicts(epoch_params=epoch_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
@@ -130,12 +136,12 @@ def compute_firing_rates(
 
 
 def compute_presence_ratios(
-    sorting,
-    sampling_frequency=None,
-    epoch_params=get_epoch_params(),
-    save_as_property=True,
-    verbose=PresenceRatio.params['verbose'],
-    unit_ids=None
+        sorting,
+        sampling_frequency=None,
+        save_as_property=True,
+        verbose=PresenceRatio.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the presence ratios for the sorted dataset.
@@ -146,24 +152,25 @@ def compute_presence_ratios(
         The sorting result to be evaluated.
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor.
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs.
     save_as_property: bool
         If True, the metric is saved as sorting property
     verbose: bool
         If True, will be verbose in metric computation.
     unit_ids: list
         List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            epoch_tuples: list
+                A list of tuples with a start and end time for each epoch
+            epoch_names: list
+                A list of strings for the names of the given epochs.
+
     Returns
     ----------
     presence_ratio_epochs: list of lists
         The presence ratios of the sorted units in the given epochs.
     """
-    ep_dict, = update_param_dicts(epoch_params=epoch_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
@@ -187,14 +194,15 @@ def compute_presence_ratios(
 
 
 def compute_isi_violations(
-    sorting,
-    isi_threshold=ISIViolation.params['isi_threshold'], 
-    min_isi=ISIViolation.params['min_isi'],
-    sampling_frequency=None,
-    epoch_params=get_epoch_params(),
-    save_as_property=True,
-    verbose=ISIViolation.params['verbose'],
-    unit_ids=None
+        sorting,
+        isi_threshold=ISIViolation.params['isi_threshold'],
+        min_isi=ISIViolation.params['min_isi'],
+        sampling_frequency=None,
+        save_as_property=True,
+        verbose=ISIViolation.params['verbose'],
+        unit_ids=None,
+        **kwargs
+
 ):
     """
     Computes and returns the isi violations for the sorted dataset.
@@ -209,24 +217,25 @@ def compute_isi_violations(
         The minimum expected isi value.
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor.
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs.
     save_as_property: bool
         If True, the metric is saved as sorting property
     verbose: bool
         If True, will be verbose in metric computation.
     unit_ids: list
         List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            epoch_tuples: list
+                A list of tuples with a start and end time for each epoch
+            epoch_names: list
+                A list of strings for the names of the given epochs.
+
     Returns
     ----------
     isi_violation_epochs: list of lists
         The isi violations of the sorted units in the given epochs.
     """
-    ep_dict, = update_param_dicts(epoch_params=epoch_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
@@ -250,16 +259,13 @@ def compute_isi_violations(
 
 
 def compute_amplitude_cutoffs(
-    sorting,
-    recording,
-    recording_params=get_recording_params(),
-    amplitude_params=get_amplitude_params(),
-    epoch_params=get_epoch_params(),
-    feature_params=get_feature_params(),
-    save_as_property=True,
-    seed=AmplitudeCutoff.params['seed'],
-    verbose=AmplitudeCutoff.params['verbose'],
-    unit_ids=None
+        sorting,
+        recording,
+        save_as_property=True,
+        seed=AmplitudeCutoff.params['seed'],
+        verbose=AmplitudeCutoff.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the amplitude cutoffs for the sorted dataset.
@@ -281,28 +287,6 @@ def compute_amplitude_cutoffs(
                 Frames before peak to compute amplitude.
             amp_frames_after: int
                 Frames after peak to compute amplitude.
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
-            apply_filter: bool
-                If True, recording is bandpass-filtered.
-            freq_min: float
-                High-pass frequency for optional filter (default 300 Hz).
-            freq_max: float
-                Low-pass frequency for optional filter (default 6000 Hz).
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs.
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
-            save_features_props: bool
-                If true, it will save amplitudes in the sorting extractor.
-            recompute_info: bool
-                    If True, waveforms are recomputed
-            max_spikes_per_unit: int
-                The maximum number of spikes to extract per unit.
     save_as_property: bool
         If True, the metric is saved as sorting property
     seed: int
@@ -311,16 +295,30 @@ def compute_amplitude_cutoffs(
         If True, will be verbose in metric computation.
     unit_ids: list
         List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            apply_filter: bool
+                If True, recording is bandpass-filtered.
+            freq_min: float
+                High-pass frequency for optional filter (default 300 Hz).
+            freq_max: float
+                Low-pass frequency for optional filter (default 6000 Hz).
+            epoch_tuples: list
+                A list of tuples with a start and end time for each epoch
+            epoch_names: list
+                A list of strings for the names of the given epochs.
+            save_features_props: bool
+                If true, it will save amplitudes in the sorting extractor.
+            recompute_info: bool
+                    If True, waveforms are recomputed
+            max_spikes_per_unit: int
+                The maximum number of spikes to extract per unit.
     Returns
     ----------
     amplitude_cutoffs_epochs: list of lists
         The amplitude cutoffs of the sorted units in the given epochs.
     """
-
-    rp_dict, ap_dict, ep_dict, fp_dict = update_param_dicts(recording_params=recording_params, 
-                                                            amplitude_params=amplitude_params, 
-                                                            epoch_params=epoch_params,
-                                                            feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
@@ -351,21 +349,20 @@ def compute_amplitude_cutoffs(
     amplitude_cutoffs_epochs = ac.compute_metric(save_as_property)
     return amplitude_cutoffs_epochs
 
+
 def compute_snrs(
-    sorting,
-    recording,
-    snr_mode=SNR.params['snr_mode'],
-    snr_noise_duration=SNR.params['snr_noise_duration'],
-    max_spikes_per_unit_for_snr=SNR.params['max_spikes_per_unit_for_snr'],
-    template_mode=SNR.params['template_mode'], 
-    max_channel_peak=SNR.params['max_channel_peak'], 
-    recording_params=get_recording_params(),
-    epoch_params=get_epoch_params(),
-    feature_params=get_feature_params(),
-    save_as_property=True,
-    seed=SNR.params['seed'],
-    verbose=SNR.params['verbose'],
-    unit_ids=None
+        sorting,
+        recording,
+        snr_mode=SNR.params['snr_mode'],
+        snr_noise_duration=SNR.params['snr_noise_duration'],
+        max_spikes_per_unit_for_snr=SNR.params['max_spikes_per_unit_for_snr'],
+        template_mode=SNR.params['template_mode'],
+        max_channel_peak=SNR.params['max_channel_peak'],
+        save_as_property=True,
+        seed=SNR.params['seed'],
+        verbose=SNR.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the snrs in the sorted dataset.
@@ -374,43 +371,38 @@ def compute_snrs(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor from which to extract amplitudes
-
     snr_mode: str
             Mode to compute noise SNR ('mad' | 'std' - default 'mad')
-            
     snr_noise_duration: float
         Number of seconds to compute noise level from (default 10.0)
-
     max_spikes_per_unit_for_snr: int
         Maximum number of spikes to compute templates from (default 1000)
-
     template_mode: str
         Use 'mean' or 'median' to compute templates
-
     max_channel_peak: str
         If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    unit_ids: list
+        List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
             apply_filter: bool
                 If True, recording is bandpass-filtered.
             freq_min: float
                 High-pass frequency for optional filter (default 300 Hz).
             freq_max: float
                 Low-pass frequency for optional filter (default 6000 Hz).
-
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
             epoch_tuples: list
                 A list of tuples with a start and end time for each epoch
             epoch_names: list
                 A list of strings for the names of the given epochs.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save amplitudes in the sorting extractor.
             recompute_info: bool
@@ -418,26 +410,12 @@ def compute_snrs(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
-    unit_ids: list
-        List of unit ids to compute metric for. If not specified, all units are used
-
     Returns
     ----------
     snr_epochs: list of lists
         The snrs of the sorted units in the given epochs.
     """
-    rp_dict, ep_dict, fp_dict = update_param_dicts(recording_params=recording_params, 
-                                                   epoch_params=epoch_params,
-                                                   feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
@@ -456,23 +434,21 @@ def compute_snrs(
     )
 
     snr = SNR(metric_data=md)
-    snr_epochs = snr.compute_metric(snr_mode, snr_noise_duration, max_spikes_per_unit_for_snr, 
+    snr_epochs = snr.compute_metric(snr_mode, snr_noise_duration, max_spikes_per_unit_for_snr,
                                     template_mode, max_channel_peak, fp_dict['save_features_props'],
                                     fp_dict['recompute_info'], seed, save_as_property)
     return snr_epochs
 
+
 def compute_silhouette_scores(
-    sorting,
-    recording,
-    max_spikes_for_silhouette=SilhouetteScore.params['max_spikes_for_silhouette'],
-    pca_scores_params=get_pca_scores_params(),
-    recording_params=get_recording_params(),
-    epoch_params=get_epoch_params(),
-    feature_params=get_feature_params(),
-    save_as_property=True,
-    seed=SilhouetteScore.params['seed'],
-    verbose=SilhouetteScore.params['verbose'],
-    unit_ids=None,
+        sorting,
+        recording,
+        max_spikes_for_silhouette=SilhouetteScore.params['max_spikes_for_silhouette'],
+        save_as_property=True,
+        seed=SilhouetteScore.params['seed'],
+        verbose=SilhouetteScore.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the silhouette scores in the sorted dataset.
@@ -481,15 +457,26 @@ def compute_silhouette_scores(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor from which to extract amplitudes
-
     max_spikes_for_silhouette: int
         Max spikes to be used for silhouette metric.
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    unit_ids: list
+        List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            apply_filter: bool
+                If True, recording is bandpass-filtered.
+            freq_min: float
+                High-pass frequency for optional filter (default 300 Hz).
+            freq_max: float
+                Low-pass frequency for optional filter (default 6000 Hz).
             ms_before: float
                 Time period in ms to cut waveforms before the spike events
             ms_after: float
@@ -500,25 +487,10 @@ def compute_silhouette_scores(
                 The maximum number of spikes to extract per unit.
             max_spikes_for_pca: int
                 The maximum number of spikes to use to compute PCA.
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
-            apply_filter: bool
-                If True, recording is bandpass-filtered.
-            freq_min: float
-                High-pass frequency for optional filter (default 300 Hz).
-            freq_max: float
-                Low-pass frequency for optional filter (default 6000 Hz).
-
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
             epoch_tuples: list
                 A list of tuples with a start and end time for each epoch
             epoch_names: list
                 A list of strings for the names of the given epochs.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save amplitudes in the sorting extractor.
             recompute_info: bool
@@ -526,27 +498,12 @@ def compute_silhouette_scores(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
-    unit_ids: list
-        List of unit ids to compute metric for. If not specified, all units are used
-
     Returns
     ----------
     silhouette_score_epochs: list of lists
         The sihouette scores of the sorted units in the given epochs.
     """
-    rp_dict, ps_dict, ep_dict, fp_dict = update_param_dicts(recording_params=recording_params, 
-                                                            pca_scores_params=pca_scores_params, 
-                                                            epoch_params=epoch_params,
-                                                            feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
@@ -565,12 +522,12 @@ def compute_silhouette_scores(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         recompute_info=fp_dict['recompute_info'],
         save_features_props=fp_dict['save_features_props'],
         seed=seed,
@@ -582,18 +539,15 @@ def compute_silhouette_scores(
 
 
 def compute_d_primes(
-    sorting,
-    recording,
-    num_channels_to_compare=DPrime.params['num_channels_to_compare'],
-    max_spikes_per_cluster=DPrime.params['max_spikes_per_cluster'],
-    pca_scores_params=get_pca_scores_params(),
-    recording_params=get_recording_params(),
-    epoch_params=get_epoch_params(),
-    feature_params=get_feature_params(),
-    save_as_property=True,
-    seed=DPrime.params['seed'],
-    verbose=DPrime.params['verbose'],
-    unit_ids=None
+        sorting,
+        recording,
+        num_channels_to_compare=DPrime.params['num_channels_to_compare'],
+        max_spikes_per_cluster=DPrime.params['max_spikes_per_cluster'],
+        save_as_property=True,
+        seed=DPrime.params['seed'],
+        verbose=DPrime.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the d primes in the sorted dataset.
@@ -602,18 +556,28 @@ def compute_d_primes(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor from which to extract amplitudes
-
     num_channels_to_compare: int
         The number of channels to be used for the PC extraction and comparison
-        
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    unit_ids: list
+        List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            apply_filter: bool
+                If True, recording is bandpass-filtered.
+            freq_min: float
+                High-pass frequency for optional filter (default 300 Hz).
+            freq_max: float
+                Low-pass frequency for optional filter (default 6000 Hz).
             ms_before: float
                 Time period in ms to cut waveforms before the spike events
             ms_after: float
@@ -624,25 +588,10 @@ def compute_d_primes(
                 The maximum number of spikes to extract per unit.
             max_spikes_for_pca: int
                 The maximum number of spikes to use to compute PCA.
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
-            apply_filter: bool
-                If True, recording is bandpass-filtered.
-            freq_min: float
-                High-pass frequency for optional filter (default 300 Hz).
-            freq_max: float
-                Low-pass frequency for optional filter (default 6000 Hz).
-
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
             epoch_tuples: list
                 A list of tuples with a start and end time for each epoch
             epoch_names: list
                 A list of strings for the names of the given epochs.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save amplitudes in the sorting extractor.
             recompute_info: bool
@@ -650,27 +599,12 @@ def compute_d_primes(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
-    unit_ids: list
-        List of unit ids to compute metric for. If not specified, all units are used
-
     Returns
     ----------
     d_prime_epochs: list of lists
         The d primes of the sorted units in the given epochs.
     """
-    rp_dict, ps_dict, ep_dict, fp_dict = update_param_dicts(recording_params=recording_params, 
-                                                            pca_scores_params=pca_scores_params, 
-                                                            epoch_params=epoch_params,
-                                                            feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
@@ -689,12 +623,12 @@ def compute_d_primes(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         recompute_info=fp_dict['recompute_info'],
         save_features_props=fp_dict['save_features_props'],
         seed=seed,
@@ -704,19 +638,17 @@ def compute_d_primes(
     d_prime_epochs = d_prime.compute_metric(num_channels_to_compare, max_spikes_per_cluster, seed, save_as_property)
     return d_prime_epochs
 
+
 def compute_l_ratios(
-    sorting,
-    recording,
-    num_channels_to_compare=LRatio.params['num_channels_to_compare'],
-    max_spikes_per_cluster=LRatio.params['max_spikes_per_cluster'],
-    pca_scores_params=get_pca_scores_params(),
-    recording_params=get_recording_params(),
-    epoch_params=get_epoch_params(),
-    feature_params=get_feature_params(),
-    save_as_property=True,
-    seed=LRatio.params['seed'],
-    verbose=LRatio.params['verbose'],
-    unit_ids=None
+        sorting,
+        recording,
+        num_channels_to_compare=LRatio.params['num_channels_to_compare'],
+        max_spikes_per_cluster=LRatio.params['max_spikes_per_cluster'],
+        save_as_property=True,
+        seed=LRatio.params['seed'],
+        verbose=LRatio.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the l ratios in the sorted dataset.
@@ -725,18 +657,28 @@ def compute_l_ratios(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor from which to extract amplitudes
-
     num_channels_to_compare: int
         The number of channels to be used for the PC extraction and comparison
-        
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    unit_ids: list
+        List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            apply_filter: bool
+                If True, recording is bandpass-filtered.
+            freq_min: float
+                High-pass frequency for optional filter (default 300 Hz).
+            freq_max: float
+                Low-pass frequency for optional filter (default 6000 Hz).
             ms_before: float
                 Time period in ms to cut waveforms before the spike events
             ms_after: float
@@ -747,25 +689,10 @@ def compute_l_ratios(
                 The maximum number of spikes to extract per unit.
             max_spikes_for_pca: int
                 The maximum number of spikes to use to compute PCA.
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
-            apply_filter: bool
-                If True, recording is bandpass-filtered.
-            freq_min: float
-                High-pass frequency for optional filter (default 300 Hz).
-            freq_max: float
-                Low-pass frequency for optional filter (default 6000 Hz).
-
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
             epoch_tuples: list
                 A list of tuples with a start and end time for each epoch
             epoch_names: list
                 A list of strings for the names of the given epochs.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save amplitudes in the sorting extractor.
             recompute_info: bool
@@ -773,27 +700,13 @@ def compute_l_ratios(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
-    unit_ids: list
-        List of unit ids to compute metric for. If not specified, all units are used
-
     Returns
     ----------
     l_ratio_epochs: list of lists
         The l ratios of the sorted units in the given epochs.
     """
-    rp_dict, ps_dict, ep_dict, fp_dict = update_param_dicts(recording_params=recording_params, 
-                                                            pca_scores_params=pca_scores_params, 
-                                                            epoch_params=epoch_params,
-                                                            feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
+
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
 
@@ -811,12 +724,12 @@ def compute_l_ratios(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         recompute_info=fp_dict['recompute_info'],
         save_features_props=fp_dict['save_features_props'],
         seed=seed,
@@ -828,18 +741,15 @@ def compute_l_ratios(
 
 
 def compute_isolation_distances(
-    sorting,
-    recording,
-    num_channels_to_compare=IsolationDistance.params['num_channels_to_compare'],
-    max_spikes_per_cluster=IsolationDistance.params['max_spikes_per_cluster'],
-    pca_scores_params=get_pca_scores_params(),
-    recording_params=get_recording_params(),
-    epoch_params=get_epoch_params(),
-    feature_params=get_feature_params(),
-    save_as_property=True,
-    seed=IsolationDistance.params['seed'],
-    verbose=IsolationDistance.params['verbose'],
-    unit_ids=None,
+        sorting,
+        recording,
+        num_channels_to_compare=IsolationDistance.params['num_channels_to_compare'],
+        max_spikes_per_cluster=IsolationDistance.params['max_spikes_per_cluster'],
+        save_as_property=True,
+        seed=IsolationDistance.params['seed'],
+        verbose=IsolationDistance.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the isolation distances in the sorted dataset.
@@ -851,15 +761,26 @@ def compute_isolation_distances(
 
     recording: RecordingExtractor
         The given recording extractor from which to extract amplitudes
-
     num_channels_to_compare: int
         The number of channels to be used for the PC extraction and comparison
-        
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    unit_ids: list
+        List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            apply_filter: bool
+                If True, recording is bandpass-filtered.
+            freq_min: float
+                High-pass frequency for optional filter (default 300 Hz).
+            freq_max: float
+                Low-pass frequency for optional filter (default 6000 Hz).
             ms_before: float
                 Time period in ms to cut waveforms before the spike events
             ms_after: float
@@ -870,25 +791,10 @@ def compute_isolation_distances(
                 The maximum number of spikes to extract per unit.
             max_spikes_for_pca: int
                 The maximum number of spikes to use to compute PCA.
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
-            apply_filter: bool
-                If True, recording is bandpass-filtered.
-            freq_min: float
-                High-pass frequency for optional filter (default 300 Hz).
-            freq_max: float
-                Low-pass frequency for optional filter (default 6000 Hz).
-
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
             epoch_tuples: list
                 A list of tuples with a start and end time for each epoch
             epoch_names: list
                 A list of strings for the names of the given epochs.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save amplitudes in the sorting extractor.
             recompute_info: bool
@@ -896,29 +802,15 @@ def compute_isolation_distances(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
-    unit_ids: list
-        List of unit ids to compute metric for. If not specified, all units are used
     Returns
     ----------
     isolation_distance_epochs: list of lists
         The isolation distances of the sorted units in the given epochs.
     """
-    rp_dict, ps_dict, ep_dict, fp_dict = update_param_dicts(recording_params=recording_params, 
-                                                            pca_scores_params=pca_scores_params, 
-                                                            epoch_params=epoch_params,
-                                                            feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
-       unit_ids = sorting.get_unit_ids()
+        unit_ids = sorting.get_unit_ids()
 
     md = MetricData(
         sorting=sorting,
@@ -934,36 +826,35 @@ def compute_isolation_distances(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         recompute_info=fp_dict['recompute_info'],
         save_features_props=fp_dict['save_features_props'],
         seed=seed,
     )
 
     isolation_distance = IsolationDistance(metric_data=md)
-    isolation_distance_epochs = isolation_distance.compute_metric(num_channels_to_compare, max_spikes_per_cluster, seed, save_as_property)
+    isolation_distance_epochs = isolation_distance.compute_metric(num_channels_to_compare, max_spikes_per_cluster, seed,
+                                                                  save_as_property)
     return isolation_distance_epochs
 
+
 def compute_nn_metrics(
-    sorting,
-    recording,
-    num_channels_to_compare=NearestNeighbor.params['num_channels_to_compare'],
-    max_spikes_per_cluster=NearestNeighbor.params['max_spikes_per_cluster'],
-    max_spikes_for_nn=NearestNeighbor.params['max_spikes_for_nn'],
-    n_neighbors=NearestNeighbor.params['n_neighbors'],
-    pca_scores_params=get_pca_scores_params(),
-    recording_params=get_recording_params(),
-    epoch_params=get_epoch_params(),
-    feature_params=get_feature_params(),
-    save_as_property=True,
-    seed=NearestNeighbor.params['seed'],
-    verbose=NearestNeighbor.params['verbose'],
-    unit_ids=None,
+        sorting,
+        recording,
+        num_channels_to_compare=NearestNeighbor.params['num_channels_to_compare'],
+        max_spikes_per_cluster=NearestNeighbor.params['max_spikes_per_cluster'],
+        max_spikes_for_nn=NearestNeighbor.params['max_spikes_for_nn'],
+        n_neighbors=NearestNeighbor.params['n_neighbors'],
+        save_as_property=True,
+        seed=NearestNeighbor.params['seed'],
+        verbose=NearestNeighbor.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the nearest neighbor metrics in the sorted dataset.
@@ -972,24 +863,32 @@ def compute_nn_metrics(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor from which to extract amplitudes
-
     num_channels_to_compare: int
         The number of channels to be used for the PC extraction and comparison
-        
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-
     max_spikes_for_nn: int
         Max spikes to be used for nearest-neighbors calculation.
-    
     n_neighbors: int
         Number of neighbors to compare.
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    unit_ids: list
+        List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            apply_filter: bool
+                If True, recording is bandpass-filtered.
+            freq_min: float
+                High-pass frequency for optional filter (default 300 Hz).
+            freq_max: float
+                Low-pass frequency for optional filter (default 6000 Hz).
             ms_before: float
                 Time period in ms to cut waveforms before the spike events
             ms_after: float
@@ -1000,25 +899,10 @@ def compute_nn_metrics(
                 The maximum number of spikes to extract per unit.
             max_spikes_for_pca: int
                 The maximum number of spikes to use to compute PCA.
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
-            apply_filter: bool
-                If True, recording is bandpass-filtered.
-            freq_min: float
-                High-pass frequency for optional filter (default 300 Hz).
-            freq_max: float
-                Low-pass frequency for optional filter (default 6000 Hz).
-
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
             epoch_tuples: list
                 A list of tuples with a start and end time for each epoch
             epoch_names: list
                 A list of strings for the names of the given epochs.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save amplitudes in the sorting extractor.
             recompute_info: bool
@@ -1026,27 +910,12 @@ def compute_nn_metrics(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
-    unit_ids: list
-        List of unit ids to compute metric for. If not specified, all units are used
-
     Returns
     ----------
     nn_metrics_epochs: list of lists
         The nearest neighbor metrics of the sorted units in the given epochs.
     """
-    rp_dict, ps_dict, ep_dict, fp_dict = update_param_dicts(recording_params=recording_params, 
-                                                            pca_scores_params=pca_scores_params, 
-                                                            epoch_params=epoch_params,
-                                                            feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
@@ -1065,35 +934,33 @@ def compute_nn_metrics(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         recompute_info=fp_dict['recompute_info'],
         save_features_props=fp_dict['save_features_props'],
         seed=seed,
     )
 
     nn = NearestNeighbor(metric_data=md)
-    nn_metrics_epochs = nn.compute_metric(num_channels_to_compare, max_spikes_per_cluster, 
+    nn_metrics_epochs = nn.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
                                           max_spikes_for_nn, n_neighbors, seed, save_as_property)
     return nn_metrics_epochs
 
+
 def compute_drift_metrics(
-    sorting,
-    recording,
-    drift_metrics_interval_s=DriftMetric.params['drift_metrics_interval_s'],
-    drift_metrics_min_spikes_per_interval=DriftMetric.params['drift_metrics_min_spikes_per_interval'],
-    pca_scores_params=get_pca_scores_params(),
-    recording_params=get_recording_params(),
-    epoch_params=get_epoch_params(),
-    feature_params=get_feature_params(),
-    save_as_property=True,
-    seed=DriftMetric.params['seed'],
-    verbose=DriftMetric.params['verbose'],
-    unit_ids=None,
+        sorting,
+        recording,
+        drift_metrics_interval_s=DriftMetric.params['drift_metrics_interval_s'],
+        drift_metrics_min_spikes_per_interval=DriftMetric.params['drift_metrics_min_spikes_per_interval'],
+        save_as_property=True,
+        seed=DriftMetric.params['seed'],
+        verbose=DriftMetric.params['verbose'],
+        unit_ids=None,
+        **kwargs
 ):
     """
     Computes and returns the drift metrics in the sorted dataset.
@@ -1102,18 +969,28 @@ def compute_drift_metrics(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor from which to extract amplitudes
-
     drift_metrics_interval_s: float
         Time period for evaluating drift.
-
     drift_metrics_min_spikes_per_interval: int
         Minimum number of spikes for evaluating drift metrics per interval.
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    unit_ids: list
+        List of unit ids to compute metric for. If not specified, all units are used
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            apply_filter: bool
+                If True, recording is bandpass-filtered.
+            freq_min: float
+                High-pass frequency for optional filter (default 300 Hz).
+            freq_max: float
+                Low-pass frequency for optional filter (default 6000 Hz).
             ms_before: float
                 Time period in ms to cut waveforms before the spike events
             ms_after: float
@@ -1124,25 +1001,10 @@ def compute_drift_metrics(
                 The maximum number of spikes to extract per unit.
             max_spikes_for_pca: int
                 The maximum number of spikes to use to compute PCA.
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
-            apply_filter: bool
-                If True, recording is bandpass-filtered.
-            freq_min: float
-                High-pass frequency for optional filter (default 300 Hz).
-            freq_max: float
-                Low-pass frequency for optional filter (default 6000 Hz).
-
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
             epoch_tuples: list
                 A list of tuples with a start and end time for each epoch
             epoch_names: list
                 A list of strings for the names of the given epochs.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save amplitudes in the sorting extractor.
             recompute_info: bool
@@ -1150,27 +1012,12 @@ def compute_drift_metrics(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
-    unit_ids: list
-        List of unit ids to compute metric for. If not specified, all units are used
-
     Returns
     ----------
     dm_metrics_epochs: list of lists
         The drift metrics of the sorted units in the given epochs.
     """
-    rp_dict, ps_dict, ep_dict, fp_dict = update_param_dicts(recording_params=recording_params, 
-                                                            pca_scores_params=pca_scores_params, 
-                                                            epoch_params=epoch_params,
-                                                            feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
 
     if unit_ids is None:
         unit_ids = sorting.get_unit_ids()
@@ -1189,124 +1036,108 @@ def compute_drift_metrics(
     )
 
     md.compute_pca_scores(
-        n_comp=ps_dict["n_comp"],
-        ms_before=ps_dict["ms_before"],
-        ms_after=ps_dict["ms_after"],
-        dtype=ps_dict["dtype"],
+        n_comp=pca_dict["n_comp"],
+        ms_before=pca_dict["ms_before"],
+        ms_after=pca_dict["ms_after"],
+        dtype=pca_dict["dtype"],
         max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-        max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+        max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
         recompute_info=fp_dict['recompute_info'],
         save_features_props=fp_dict['save_features_props'],
         seed=seed,
     )
 
     dm = DriftMetric(metric_data=md)
-    dm_metrics_epochs = dm.compute_metric(drift_metrics_interval_s, drift_metrics_min_spikes_per_interval, save_as_property)
+    dm_metrics_epochs = dm.compute_metric(drift_metrics_interval_s, drift_metrics_min_spikes_per_interval,
+                                          save_as_property)
     return dm_metrics_epochs
 
+
 def compute_metrics(
-    sorting,
-    recording=None,
-    sampling_frequency=None,
-    metric_names=None,
-    isi_threshold=ISIViolation.params['isi_threshold'],
-    min_isi=ISIViolation.params['min_isi'],
-    snr_mode=SNR.params['snr_mode'],
-    snr_noise_duration=SNR.params['snr_noise_duration'],
-    max_spikes_per_unit_for_snr=SNR.params['max_spikes_per_unit_for_snr'],
-    template_mode=SNR.params['template_mode'], 
-    max_channel_peak=SNR.params['max_channel_peak'], 
-    drift_metrics_interval_s=DriftMetric.params['drift_metrics_interval_s'],
-    drift_metrics_min_spikes_per_interval=DriftMetric.params['drift_metrics_min_spikes_per_interval'],
-    max_spikes_for_silhouette=SilhouetteScore.params['max_spikes_for_silhouette'],
-    num_channels_to_compare=13,
-    max_spikes_per_cluster=500,
-    max_spikes_for_nn=NearestNeighbor.params['max_spikes_for_nn'],
-    n_neighbors=NearestNeighbor.params['n_neighbors'],
-    amplitude_params=get_amplitude_params(),
-    pca_scores_params=get_pca_scores_params(),
-    recording_params=get_recording_params(),
-    epoch_params=get_epoch_params(),
-    feature_params=get_feature_params(),
-    save_as_property=True,
-    seed=None,
-    verbose=False,
-    unit_ids=None,
-    return_dict=True
+        sorting,
+        recording=None,
+        sampling_frequency=None,
+        metric_names=None,
+        isi_threshold=ISIViolation.params['isi_threshold'],
+        min_isi=ISIViolation.params['min_isi'],
+        snr_mode=SNR.params['snr_mode'],
+        snr_noise_duration=SNR.params['snr_noise_duration'],
+        max_spikes_per_unit_for_snr=SNR.params['max_spikes_per_unit_for_snr'],
+        template_mode=SNR.params['template_mode'],
+        max_channel_peak=SNR.params['max_channel_peak'],
+        drift_metrics_interval_s=DriftMetric.params['drift_metrics_interval_s'],
+        drift_metrics_min_spikes_per_interval=DriftMetric.params['drift_metrics_min_spikes_per_interval'],
+        max_spikes_for_silhouette=SilhouetteScore.params['max_spikes_for_silhouette'],
+        num_channels_to_compare=13,
+        max_spikes_per_cluster=500,
+        max_spikes_for_nn=NearestNeighbor.params['max_spikes_for_nn'],
+        n_neighbors=NearestNeighbor.params['n_neighbors'],
+        save_as_property=True,
+        seed=None,
+        verbose=False,
+        unit_ids=None,
+        return_dict=True,
+        **kwargs
 ):
     """
     Computes and returns all specified metrics for the sorted dataset.
-
+    
     Parameters
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-
     recording: RecordingExtractor
         The given recording extractor from which to extract amplitudes
-
-   sampling_frequency: float
+    sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor.
-
     metric_names: list
         List of metric names to be computed.
-
     isi_threshold: float
         The isi threshold for calculating isi violations.
-
     min_isi: float
         The minimum expected isi value.
-
     snr_mode: str
             Mode to compute noise SNR ('mad' | 'std' - default 'mad')
-            
     snr_noise_duration: float
         Number of seconds to compute noise level from (default 10.0)
-
     max_spikes_per_unit_for_snr: int
         Maximum number of spikes to compute templates from (default 1000)
-
     template_mode: str
         Use 'mean' or 'median' to compute templates
-
     max_channel_peak: str
         If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-
     drift_metrics_interval_s: float
         Time period for evaluating drift.
-
     drift_metrics_min_spikes_per_interval: int
         Minimum number of spikes for evaluating drift metrics per interval.
-
     max_spikes_for_silhouette: int
         Max spikes to be used for silhouette metric.
-    
     num_channels_to_compare: int
         The number of channels to be used for the PC extraction and comparison
-        
     max_spikes_per_cluster: int
         Max spikes to be used from each unit
-
     max_spikes_for_nn: int
         Max spikes to be used for nearest-neighbors calculation.
-    
     n_neighbors: int
         Number of neighbors to compare.
-
-    amplitude_params: dict
-        This dictionary should contain any subset of the following parameters:
-            amp_method: str
-                If 'absolute' (default), amplitudes are absolute amplitudes in uV are returned.
-                If 'relative', amplitudes are returned as ratios between waveform amplitudes and template amplitudes.
-            amp_peak: str
-                If maximum channel has to be found among negative peaks ('neg'), positive ('pos') or both ('both' - default)
-            amp_frames_before: int
-                Frames before peak to compute amplitude.
-            amp_frames_after: int
-                Frames after peak to compute amplitude.
-
-    pca_scores_params: dict
-        This dictionary should contain any subset of the following parameters:
+    save_as_property: bool
+        If True, the metric is saved as sorting property
+    seed: int
+        Random seed for reproducibility
+    verbose: bool
+        If True, will be verbose in metric computation.
+    unit_ids: list
+        List of unit ids to compute metric for. If not specified, all units are used
+    return_dict: bool
+        If True, will return dict of metrics.
+    **kwargs: keyword arguments
+        Keyword arguments among the following:
+            apply_filter: bool
+                If True, recording is bandpass-filtered.
+            freq_min: float
+                High-pass frequency for optional filter (default 300 Hz).
+            freq_max: float
+                Low-pass frequency for optional filter (default 6000 Hz).
             ms_before: float
                 Time period in ms to cut waveforms before the spike events
             ms_after: float
@@ -1317,25 +1148,10 @@ def compute_metrics(
                 The maximum number of spikes to extract per unit.
             max_spikes_for_pca: int
                 The maximum number of spikes to use to compute PCA.
-
-    recording_params: dict
-        This dictionary should contain any subset of the following parameters:
-            apply_filter: bool
-                If True, recording is bandpass-filtered.
-            freq_min: float
-                High-pass frequency for optional filter (default 300 Hz).
-            freq_max: float
-                Low-pass frequency for optional filter (default 6000 Hz).
-
-    epoch_params: dict
-        This dictionary should contain any subset of the following parameters:
             epoch_tuples: list
                 A list of tuples with a start and end time for each epoch
             epoch_names: list
                 A list of strings for the names of the given epochs.
-
-    feature_params: dict
-        This dictionary should contain any subset of the following parameters:
             save_features_props: bool
                 If true, it will save amplitudes in the sorting extractor.
             recompute_info: bool
@@ -1343,20 +1159,6 @@ def compute_metrics(
             max_spikes_per_unit: int
                 The maximum number of spikes to extract per unit.
 
-    save_as_property: bool
-        If True, the metric is saved as sorting property
-
-    seed: int
-        Random seed for reproducibility
-
-    verbose: bool
-        If True, will be verbose in metric computation.
-
-    unit_ids: list
-        List of unit ids to compute metric for. If not specified, all units are used
-
-    return_dict: bool
-        If True, will return dict of metrics.
     Returns
     ----------
     metrics_epochs : list of lists
@@ -1364,13 +1166,10 @@ def compute_metrics(
     OR
     metrics_dict: OrderedDict
         Dict of metrics data. The dict consists of lists of metric data for each given epoch for each metric.
-
+    
     """
-    rp_dict, ap_dict, ps_dict, ep_dict, fp_dict = update_param_dicts(recording_params=recording_params, 
-                                                                     amplitude_params=amplitude_params,
-                                                                     pca_scores_params=pca_scores_params, 
-                                                                     epoch_params=epoch_params,
-                                                                     feature_params=feature_params)
+    rp_dict, ap_dict, pca_dict, ep_dict, fp_dict = update_param_dicts_with_kwargs(kwargs)
+
     metrics_epochs = []
     metrics_dict = OrderedDict()
     all_metrics_list = [
@@ -1417,14 +1216,14 @@ def compute_metrics(
     )
 
     if (
-        "max_drift" in metric_names
-        or "cumulative_drift" in metric_names
-        or "silhouette_score" in metric_names
-        or "isolation_distance" in metric_names
-        or "l_ratio" in metric_names
-        or "d_prime" in metric_names
-        or "nn_hit_rate" in metric_names
-        or "nn_miss_rate" in metric_names
+            "max_drift" in metric_names
+            or "cumulative_drift" in metric_names
+            or "silhouette_score" in metric_names
+            or "isolation_distance" in metric_names
+            or "l_ratio" in metric_names
+            or "d_prime" in metric_names
+            or "nn_hit_rate" in metric_names
+            or "nn_miss_rate" in metric_names
     ):
         if recording is None:
             raise ValueError(
@@ -1434,12 +1233,12 @@ def compute_metrics(
             )
         else:
             md.compute_pca_scores(
-                n_comp=ps_dict["n_comp"],
-                ms_before=ps_dict["ms_before"],
-                ms_after=ps_dict["ms_after"],
-                dtype=ps_dict["dtype"],
+                n_comp=pca_dict["n_comp"],
+                ms_before=pca_dict["ms_before"],
+                ms_after=pca_dict["ms_after"],
+                dtype=pca_dict["dtype"],
                 max_spikes_per_unit=fp_dict["max_spikes_per_unit"],
-                max_spikes_for_pca=ps_dict["max_spikes_for_pca"],
+                max_spikes_for_pca=pca_dict["max_spikes_for_pca"],
                 recompute_info=fp_dict['recompute_info'],
                 save_features_props=fp_dict['save_features_props'],
                 seed=seed,
@@ -1497,7 +1296,7 @@ def compute_metrics(
 
     if "snr" in metric_names:
         snr = SNR(metric_data=md)
-        snr_epochs = snr.compute_metric(snr_mode, snr_noise_duration, max_spikes_per_unit_for_snr, 
+        snr_epochs = snr.compute_metric(snr_mode, snr_noise_duration, max_spikes_per_unit_for_snr,
                                         template_mode, max_channel_peak, fp_dict['save_features_props'],
                                         fp_dict['recompute_info'], seed, save_as_property)
         metrics_epochs.append(snr_epochs)
@@ -1505,7 +1304,8 @@ def compute_metrics(
 
     if "max_drift" in metric_names or "cumulative_drift" in metric_names:
         dm = DriftMetric(metric_data=md)
-        dm_metrics_epochs = dm.compute_metric(drift_metrics_interval_s, drift_metrics_min_spikes_per_interval, save_as_property)
+        dm_metrics_epochs = dm.compute_metric(drift_metrics_interval_s, drift_metrics_min_spikes_per_interval,
+                                              save_as_property)
         max_drifts_epochs = []
         cumulative_drifts_epochs = []
         for dm_metric in dm_metrics_epochs:
@@ -1526,7 +1326,8 @@ def compute_metrics(
 
     if "isolation_distance" in metric_names:
         isolation_distance = IsolationDistance(metric_data=md)
-        isolation_distance_epochs = isolation_distance.compute_metric(num_channels_to_compare, max_spikes_per_cluster, seed, save_as_property)
+        isolation_distance_epochs = isolation_distance.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
+                                                                      seed, save_as_property)
         metrics_epochs.append(isolation_distance_epochs)
         metrics_dict['isolation_distance'] = isolation_distance_epochs
 
@@ -1544,7 +1345,7 @@ def compute_metrics(
 
     if "nn_hit_rate" in metric_names or "nn_miss_rate" in metric_names:
         nn = NearestNeighbor(metric_data=md)
-        nn_metrics_epochs = nn.compute_metric(num_channels_to_compare, max_spikes_per_cluster, 
+        nn_metrics_epochs = nn.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
                                               max_spikes_for_nn, n_neighbors, seed, save_as_property)
         nn_hit_rates_epochs = []
         nn_miss_rates_epochs = []
@@ -1557,7 +1358,7 @@ def compute_metrics(
         if "nn_miss_rate" in metric_names:
             metrics_epochs.append(nn_miss_rates_epochs)
             metrics_dict['nn_miss_rate'] = nn_miss_rates_epochs
-        
+
     if return_dict:
         return metrics_dict
     else:

--- a/spiketoolkit/validation/validation_list.py
+++ b/spiketoolkit/validation/validation_list.py
@@ -14,18 +14,7 @@ from .quality_metrics import (
     compute_metrics,
 )
 
-from .quality_metric_classes.utils.validation_tools import (
-    get_all_metric_data,
-    get_pca_metric_data,
-    get_amplitude_metric_data,
-    get_spike_times_metrics_data,
-)
+from .quality_metric_classes.utils.validation_tools import get_all_metric_data, get_pca_metric_data, \
+    get_amplitude_metric_data, get_spike_times_metrics_data
 
-from .quality_metric_classes.parameter_dictionaries import (
-    get_recording_params,
-    get_amplitude_params,
-    get_pca_scores_params,
-    get_epoch_params,
-    get_feature_params,
-    update_param_dicts,
-)
+from .quality_metric_classes.parameter_dictionaries import get_kwargs_params


### PR DESCRIPTION
Instead of passing several parameters for the `validation` and `curation` functions, now one can use `**kwargs`. To get a list of available `**kwargs`, we can refer to the docstrings or use the function `st.validation.get_kwargs_params()` or `st.curation.get_kwargs_params()`