### PR TITLE
fix export_to_phy template_ind

### DIFF
--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1459,10 +1459,6 @@ def _get_phy_data(recording, sorting, compute_pc_features, max_channels_per_temp
             templates_ind = pc_feature_ind
         elif channel_list is not None:
             templates_ind = np.array(channel_list)
-        else: # this part doesn't seems to work if template do not cover all channels, remove it?
-            templates_ind = np.zeros((len(templates), max_channels_per_template), dtype='int')
-            for i, temp in enumerate(templates):
-                templates_ind[i] = _select_max_channels_from_templates(temp, recording, max_channels_per_template)
     else:
         templates_ind = np.tile(np.arange(recording.get_num_channels()), (len(sorting.get_unit_ids()), 1))
 

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1347,7 +1347,7 @@ def _get_quality_metric_data(recording, sorting, n_comp, ms_before, ms_after, dt
     pc_feature_ind = pc_ind
 
     return spike_times, spike_times_amps, spike_times_pca, spike_clusters, spike_clusters_amps, spike_clusters_pca, \
-           amplitudes, pc_features, pc_feature_ind, templates
+           amplitudes, pc_features, pc_feature_ind, templates, channel_list
 
 
 def _get_phy_data(recording, sorting, compute_pc_features, max_channels_per_template, **kwargs):
@@ -1400,7 +1400,7 @@ def _get_phy_data(recording, sorting, compute_pc_features, max_channels_per_temp
         channel_groups = np.array([0] * recording.get_num_channels())
 
     spike_times, spike_times_amps, spike_times_pca, spike_clusters, spike_clusters_amps, spike_clusters_pca, \
-    amplitudes, pc_features, pc_feature_ind, templates \
+    amplitudes, pc_features, pc_feature_ind, templates, channel_list \
         = _get_quality_metric_data(recording, sorting, n_comp=n_comp, ms_before=ms_before, ms_after=ms_after,
                                    dtype=dtype, amp_method=amp_method, amp_peak=amp_peak,
                                    amp_frames_before=amp_frames_before,
@@ -1457,7 +1457,9 @@ def _get_phy_data(recording, sorting, compute_pc_features, max_channels_per_temp
         # waveforms, templates, and pc_scores are computed on the same channels
         if pc_feature_ind is not None:
             templates_ind = pc_feature_ind
-        else:
+        elif channel_list is not None:
+            templates_ind = np.array(channel_list)
+        else: # this part doesn't seems to work if template do not cover all channels, remove it?
             templates_ind = np.zeros((len(templates), max_channels_per_template), dtype='int')
             for i, temp in enumerate(templates):
                 templates_ind[i] = _select_max_channels_from_templates(temp, recording, max_channels_per_template)

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1495,6 +1495,7 @@ def _select_max_channels_from_waveforms(wf, recording, max_channels):
         max_channel_idxs = np.arange(recording.get_num_channels())
 
     return max_channel_idxs
+  
 
 def _get_max_channels_per_waveforms(recording, grouping_property, channel_ids, max_channels_per_waveforms):
     if grouping_property is None:

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1455,10 +1455,12 @@ def _get_phy_data(recording, sorting, compute_pc_features, max_channels_per_temp
         templates = templates_red
     elif max_channels_per_template < recording.get_num_channels():
         # waveforms, templates, and pc_scores are computed on the same channels
-        if pc_feature_ind is not None:
-            templates_ind = pc_feature_ind
-        elif channel_list is not None:
+        if channel_list is not None:
             templates_ind = np.array(channel_list)
+        elif pc_feature_ind is not None:
+            templates_ind = pc_feature_ind
+        else:
+            assert False, "???"
     else:
         templates_ind = np.tile(np.arange(recording.get_num_channels()), (len(sorting.get_unit_ids()), 1))
 

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1460,7 +1460,8 @@ def _get_phy_data(recording, sorting, compute_pc_features, max_channels_per_temp
         elif pc_feature_ind is not None:
             templates_ind = pc_feature_ind
         else:
-            assert False, "???"
+            templates_ind = None 
+        
     else:
         templates_ind = np.tile(np.arange(recording.get_num_channels()), (len(sorting.get_unit_ids()), 1))
 

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1496,29 +1496,6 @@ def _select_max_channels_from_waveforms(wf, recording, max_channels):
 
     return max_channel_idxs
 
-
-def _select_max_channels_from_templates(template, recording, max_channels):
-    # select based on adjacency
-    template = template.swapaxes(0, 1)
-    if max_channels < recording.get_num_channels():
-        if 'location' in recording.get_shared_channel_property_names():
-            max_channel_idx = np.unravel_index(np.argmax(np.abs(template)),
-                                               template.shape)[0]
-            locs = recording.get_channel_locations()
-            loc_max = locs[recording.get_channel_ids().index(max_channel_idx)]
-            distances = [np.linalg.norm(l - loc_max) for l in locs]
-            max_channel_idxs = np.argsort(distances)[:max_channels]
-        else:  # select based on amplitude
-            peak_idx = np.unravel_index(np.argmax(np.abs(template)),
-                                        template.shape)[1]
-            max_channel_idxs = np.argsort(np.abs(
-                template[:, peak_idx]))[::-1][:max_channels]
-    else:
-        max_channel_idxs = np.arange(recording.get_num_channels())
-
-    return max_channel_idxs
-
-
 def _get_max_channels_per_waveforms(recording, grouping_property, channel_ids, max_channels_per_waveforms):
     if grouping_property is None:
         if max_channels_per_waveforms is None:


### PR DESCRIPTION
Hi :)
If compute_pc_features was False templates_ind.py was wrong. 
Because it used pc_feature_ind to be calculated and that the new method for calculate template ind without pca_ind was wrong (work with template without all channels). 
So I use channel_list return when waveform are exctracted that appear to be the same as pc_feature_ind. 

I don't remove the old method l 1462 but maybe we can?