### PR TITLE
Removing epochs from quality metrics [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   # spikeextractors is taken from github to get latest version
   - pip install https://github.com/SpikeInterface/spikeextractors/archive/master.zip
   - pip install https://github.com/SpikeInterface/spikesorters/archive/master.zip
-  - pip install --force-reinstall https://github.com/SpikeInterface/spikemetrics/archive/master.zip
+  - pip install https://github.com/SpikeInterface/spikemetrics/archive/master.zip
   - pip install .
   - pip install pytest==4.3
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   # spikeextractors is taken from github to get latest version
   - pip install https://github.com/SpikeInterface/spikeextractors/archive/master.zip
   - pip install https://github.com/SpikeInterface/spikesorters/archive/master.zip
-  - pip install https://github.com/SpikeInterface/spikemetrics/archive/master.zip
+  - pip install --force-reinstall https://github.com/SpikeInterface/spikemetrics/archive/master.zip
   - pip install .
   - pip install pytest==4.3
 script:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'numpy',
         'spikeextractors',
         'spikesorters',
-        'spikemetrics',
+        'spikemetrics >= 0.1.5',
         'scikit-learn',
         'scipy',
         'pandas',

--- a/spiketoolkit/curation/threshold_metrics.py
+++ b/spiketoolkit/curation/threshold_metrics.py
@@ -51,8 +51,7 @@ def threshold_num_spikes(
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None, apply_filter=False,
-                    freq_min=300.0, freq_max=6000.0, unit_ids=None, epoch_tuples=None, epoch_names=None,
-                    verbose=params_dict['verbose'])
+                    freq_min=300.0, freq_max=6000.0, unit_ids=None, verbose=params_dict['verbose'])
 
     ns = NumSpikes(metric_data=md)
     threshold_sorting = ns.threshold_metric(threshold, threshold_sign, **kwargs)
@@ -96,8 +95,7 @@ def threshold_firing_rates(
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None, apply_filter=False,
-                    freq_min=300.0, freq_max=6000.0, unit_ids=None, epoch_tuples=None, epoch_names=None,
-                    verbose=params_dict['verbose'])
+                    freq_min=300.0, freq_max=6000.0, unit_ids=None, verbose=params_dict['verbose'])
 
     fr = FiringRate(metric_data=md)
     threshold_sorting = fr.threshold_metric(threshold, threshold_sign, **kwargs)
@@ -141,8 +139,7 @@ def threshold_presence_ratios(
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None, apply_filter=False,
-                    freq_min=300.0, freq_max=6000.0, unit_ids=None, epoch_tuples=None, epoch_names=None,
-                    verbose=params_dict['verbose'])
+                    freq_min=300.0, freq_max=6000.0, unit_ids=None, verbose=params_dict['verbose'])
 
     pr = PresenceRatio(metric_data=md)
     threshold_sorting = pr.threshold_metric(threshold, threshold_sign, **kwargs)
@@ -192,8 +189,7 @@ def threshold_isi_violations(
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None, apply_filter=False,
-                    freq_min=300.0, freq_max=6000.0, unit_ids=None, epoch_tuples=None, epoch_names=None,
-                    verbose=params_dict['verbose'])
+                    freq_min=300.0, freq_max=6000.0, unit_ids=None, verbose=params_dict['verbose'])
 
     iv = ISIViolation(metric_data=md)
     threshold_sorting = iv.threshold_metric(threshold, threshold_sign, isi_threshold, min_isi, **kwargs)
@@ -256,8 +252,7 @@ def threshold_amplitude_cutoffs(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, epoch_tuples=None,
-                    epoch_names=None, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
     md.compute_amplitudes(**kwargs)
 
     ac = AmplitudeCutoff(metric_data=md)
@@ -358,8 +353,7 @@ def threshold_snrs(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, epoch_tuples=None,
-                    epoch_names=None, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     snr = SNR(metric_data=md)
     threshold_sorting = snr.threshold_metric(threshold, threshold_sign, snr_mode, snr_noise_duration,
@@ -448,8 +442,7 @@ def threshold_silhouette_scores(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, epoch_tuples=None,
-                    epoch_names=None, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -543,8 +536,7 @@ def threshold_d_primes(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, epoch_tuples=None,
-                    epoch_names=None, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -638,8 +630,7 @@ def threshold_l_ratios(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, epoch_tuples=None,
-                    epoch_names=None, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -733,8 +724,7 @@ def threshold_isolation_distances(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, epoch_tuples=None,
-                    epoch_names=None, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -837,8 +827,7 @@ def threshold_nn_metrics(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, epoch_tuples=None,
-                    epoch_names=None, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -935,8 +924,7 @@ def threshold_drift_metrics(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, epoch_tuples=None,
-                    epoch_names=None, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 

--- a/spiketoolkit/curation/threshold_metrics.py
+++ b/spiketoolkit/curation/threshold_metrics.py
@@ -51,7 +51,7 @@ def threshold_num_spikes(
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None, apply_filter=False,
-                    freq_min=300.0, freq_max=6000.0, unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_min=300.0, freq_max=6000.0, unit_ids=None, verbose=params_dict['verbose'])
 
     ns = NumSpikes(metric_data=md)
     threshold_sorting = ns.threshold_metric(threshold, threshold_sign, **kwargs)
@@ -62,6 +62,7 @@ def threshold_firing_rates(
         sorting,
         threshold,
         threshold_sign,
+        duration_in_frames,
         sampling_frequency=None,
         **kwargs
 ):
@@ -79,6 +80,8 @@ def threshold_firing_rates(
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold
         If 'greater', will threshold any metric greater than the given threshold
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold
+    duration_in_frames: int
+        Length of recording (in frames).
     sampling_frequency:
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor
     **kwargs: keyword arguments
@@ -95,7 +98,8 @@ def threshold_firing_rates(
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None, apply_filter=False,
-                    freq_min=300.0, freq_max=6000.0, unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=duration_in_frames, freq_min=300.0, freq_max=6000.0, unit_ids=None, 
+                    verbose=params_dict['verbose'])
 
     fr = FiringRate(metric_data=md)
     threshold_sorting = fr.threshold_metric(threshold, threshold_sign, **kwargs)
@@ -106,6 +110,7 @@ def threshold_presence_ratios(
         sorting,
         threshold,
         threshold_sign,
+        duration_in_frames,
         sampling_frequency=None,
         **kwargs
 ):
@@ -123,6 +128,8 @@ def threshold_presence_ratios(
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold
         If 'greater', will threshold any metric greater than the given threshold
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold
+    duration_in_frames: int
+        Length of recording (in frames).
     sampling_frequency:
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor
     **kwargs: keyword arguments
@@ -139,7 +146,8 @@ def threshold_presence_ratios(
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None, apply_filter=False,
-                    freq_min=300.0, freq_max=6000.0, unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=duration_in_frames, freq_min=300.0, freq_max=6000.0, unit_ids=None, 
+                    verbose=params_dict['verbose'])
 
     pr = PresenceRatio(metric_data=md)
     threshold_sorting = pr.threshold_metric(threshold, threshold_sign, **kwargs)
@@ -150,6 +158,7 @@ def threshold_isi_violations(
         sorting,
         threshold,
         threshold_sign,
+        duration_in_frames,
         isi_threshold=ISIViolation.params['isi_threshold'],
         min_isi=ISIViolation.params['min_isi'],
         sampling_frequency=None,
@@ -169,6 +178,8 @@ def threshold_isi_violations(
         If 'less_or_equal', will threshold any metric less than or equal to the given threshold
         If 'greater', will threshold any metric greater than the given threshold
         If 'greater_or_equal', will threshold any metric greater than or equal to the given threshold
+    duration_in_frames: int
+        Length of recording (in frames).
     isi_threshold: float
         The isi threshold for calculating isi violations.
     min_isi: float
@@ -189,7 +200,8 @@ def threshold_isi_violations(
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None, apply_filter=False,
-                    freq_min=300.0, freq_max=6000.0, unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=duration_in_frames, freq_min=300.0, freq_max=6000.0, unit_ids=None, 
+                    verbose=params_dict['verbose'])
 
     iv = ISIViolation(metric_data=md)
     threshold_sorting = iv.threshold_metric(threshold, threshold_sign, isi_threshold, min_isi, **kwargs)
@@ -252,7 +264,7 @@ def threshold_amplitude_cutoffs(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
     md.compute_amplitudes(**kwargs)
 
     ac = AmplitudeCutoff(metric_data=md)
@@ -353,7 +365,7 @@ def threshold_snrs(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     snr = SNR(metric_data=md)
     threshold_sorting = snr.threshold_metric(threshold, threshold_sign, snr_mode, snr_noise_duration,
@@ -442,7 +454,7 @@ def threshold_silhouette_scores(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -536,7 +548,7 @@ def threshold_d_primes(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -630,7 +642,7 @@ def threshold_l_ratios(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -724,7 +736,7 @@ def threshold_isolation_distances(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -827,7 +839,7 @@ def threshold_nn_metrics(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -924,7 +936,7 @@ def threshold_drift_metrics(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_max=params_dict["freq_max"], unit_ids=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1101,7 +1101,7 @@ def export_to_phy(recording, sorting, output_folder, compute_pc_features=True,
             empty_flag = True
     if empty_flag:
         print('Warning: empty units have been removed when being exported to Phy')
-        sorting = st.curation.threshold_num_spikes(sorting, 1)
+        sorting = st.curation.threshold_num_spikes(sorting, 1, "less")
 
     if len(sorting.get_unit_ids()) == 0:
         raise Exception("No non-empty units in the sorting result, can't save to phy.")

--- a/spiketoolkit/tests/test_curation.py
+++ b/spiketoolkit/tests/test_curation.py
@@ -54,7 +54,7 @@ def test_thresh_isi_violations():
     s_threshold = 0.01
 
     sort_isi = threshold_isi_violations(sort, s_threshold, 'greater', rec.get_num_frames())
-    new_isi = compute_isi_violations(sort_isi, sort.get_sampling_frequency())
+    new_isi = compute_isi_violations(sort_isi, rec.get_num_frames(), sort.get_sampling_frequency())
 
     assert np.all(new_isi <= s_threshold)
     check_dumping(sort_isi)
@@ -67,7 +67,7 @@ def test_thresh_presence_ratios():
     s_threshold = 0.18
 
     sort_pr = threshold_presence_ratios(sort, s_threshold, 'less', rec.get_num_frames())
-    new_pr = compute_presence_ratios(sort_pr, sort.get_sampling_frequency())
+    new_pr = compute_presence_ratios(sort_pr, rec.get_num_frames(), sort.get_sampling_frequency())
 
     assert np.all(new_pr < s_threshold)
     check_dumping(sort_pr)

--- a/spiketoolkit/tests/test_curation.py
+++ b/spiketoolkit/tests/test_curation.py
@@ -69,7 +69,7 @@ def test_thresh_presence_ratios():
     sort_pr = threshold_presence_ratios(sort, s_threshold, 'less', rec.get_num_frames())
     new_pr = compute_presence_ratios(sort_pr, rec.get_num_frames(), sort.get_sampling_frequency())
 
-    assert np.all(new_pr < s_threshold)
+    assert np.all(new_pr >= s_threshold)
     check_dumping(sort_pr)
     shutil.rmtree('test')
 

--- a/spiketoolkit/tests/test_curation.py
+++ b/spiketoolkit/tests/test_curation.py
@@ -41,7 +41,7 @@ def test_thresh_num_spikes():
     s_threshold = 25
 
     sort_ns = threshold_num_spikes(sort, s_threshold, 'less')
-    new_ns = compute_num_spikes(sort_ns, sort.get_sampling_frequency())[0]
+    new_ns = compute_num_spikes(sort_ns, sort.get_sampling_frequency())
 
     assert np.all(new_ns >= s_threshold)
     check_dumping(sort_ns)
@@ -53,8 +53,8 @@ def test_thresh_isi_violations():
                                                 seed=0)
     s_threshold = 0.01
 
-    sort_isi = threshold_isi_violations(sort, s_threshold, 'greater')
-    new_isi = compute_isi_violations(sort_isi, sort.get_sampling_frequency())[0]
+    sort_isi = threshold_isi_violations(sort, s_threshold, 'greater', rec.get_num_frames())
+    new_isi = compute_isi_violations(sort_isi, sort.get_sampling_frequency())
 
     assert np.all(new_isi <= s_threshold)
     check_dumping(sort_isi)
@@ -66,8 +66,8 @@ def test_thresh_presence_ratios():
                                                 seed=0)
     s_threshold = 0.18
 
-    sort_pr = threshold_presence_ratios(sort, s_threshold, 'less')
-    new_pr = compute_presence_ratios(sort_pr, sort.get_sampling_frequency())[0]
+    sort_pr = threshold_presence_ratios(sort, s_threshold, 'less', rec.get_num_frames())
+    new_pr = compute_presence_ratios(sort_pr, sort.get_sampling_frequency())
 
     assert np.all(new_pr >= s_threshold)
     check_dumping(sort_pr)
@@ -82,7 +82,7 @@ def test_thresh_amplitude_cutoffs():
 
     sort_amplitude_cutoff = threshold_amplitude_cutoffs(sort, rec, amplitude_cutoff_thresh, "less",
                                                         apply_filter=False, seed=0)
-    new_amplitude_cutoff = compute_amplitude_cutoffs(sort_amplitude_cutoff, rec, apply_filter=False, seed=0)[0]
+    new_amplitude_cutoff = compute_amplitude_cutoffs(sort_amplitude_cutoff, rec, apply_filter=False, seed=0)
 
     assert np.all(new_amplitude_cutoff >= amplitude_cutoff_thresh)
     check_dumping(sort_amplitude_cutoff)
@@ -94,8 +94,8 @@ def test_thresh_frs():
                                                 seed=0)
     fr_thresh = 2
 
-    sort_fr = threshold_firing_rates(sort, fr_thresh, 'less')
-    new_fr = compute_firing_rates(sort_fr)[0]
+    sort_fr = threshold_firing_rates(sort, fr_thresh, 'less', rec.get_num_frames())
+    new_fr = compute_firing_rates(sort_fr, rec.get_num_frames())
 
     assert np.all(new_fr >= fr_thresh)
     check_dumping(sort_fr)
@@ -111,8 +111,8 @@ def test_thresh_threshold_drift_metrics():
                                        apply_filter=False, seed=0)
     sort_cum = threshold_drift_metrics(sort, rec, s_threshold, 'greater', metric_name="cumulative_drift",
                                        apply_filter=False, seed=0)
-    new_max_drift, _ = compute_drift_metrics(sort_max, rec, apply_filter=False, seed=0)[0]
-    _, new_cum_drift = compute_drift_metrics(sort_cum, rec, apply_filter=False, seed=0)[0]
+    new_max_drift, _ = compute_drift_metrics(sort_max, rec, apply_filter=False, seed=0)
+    _, new_cum_drift = compute_drift_metrics(sort_cum, rec, apply_filter=False, seed=0)
 
     assert np.all(new_max_drift <= s_threshold)
     assert np.all(new_cum_drift <= s_threshold)
@@ -128,7 +128,7 @@ def test_thresh_snrs():
     snr_thresh = 4
 
     sort_snr = threshold_snrs(sort, rec, snr_thresh, 'less', apply_filter=False, seed=0)
-    new_snr = compute_snrs(sort_snr, rec, apply_filter=False, seed=0)[0]
+    new_snr = compute_snrs(sort_snr, rec, apply_filter=False, seed=0)
 
     assert np.all(new_snr >= snr_thresh)
     check_dumping(sort_snr)
@@ -141,8 +141,8 @@ def test_thresh_isolation_distances():
                                                 seed=0)
     s_threshold = 200
 
-    iso = compute_isolation_distances(sort, rec, apply_filter=False, seed=0)[0]
-    sort_iso = threshold_isolation_distances(sort, rec, s_threshold, 'less', apply_filter=False, seed=0)
+    iso = compute_isolation_distances(sort, rec, apply_filter=False, seed=0)
+    sort_iso = threshold_isolation_distances(sort, rec, s_threshold, 'less', rec.get_num_frames(), apply_filter=False, seed=0)
 
     original_ids = sort.get_unit_ids()
     new_iso = []
@@ -159,7 +159,7 @@ def test_thresh_silhouettes():
                                                 seed=0)
     silhouette_thresh = .5
 
-    silhouette = np.asarray(compute_silhouette_scores(sort, rec, apply_filter=False, seed=0)[0])
+    silhouette = compute_silhouette_scores(sort, rec, apply_filter=False, seed=0)
     sort_silhouette = threshold_silhouette_scores(sort, rec, silhouette_thresh, "less", apply_filter=False, seed=0)
 
     original_ids = sort.get_unit_ids()
@@ -178,7 +178,7 @@ def test_thresh_nn_metrics():
     s_threshold_hit = 0.9
     s_threshold_miss = 0.002
 
-    nn_hit, nn_miss = compute_nn_metrics(sort, rec, apply_filter=False, seed=0)[0]
+    nn_hit, nn_miss = compute_nn_metrics(sort, rec, apply_filter=False, seed=0)
     sort_hit = threshold_nn_metrics(sort, rec, s_threshold_hit, 'less', metric_name="nn_hit_rate",
                                     apply_filter=False, seed=0)
     sort_miss = threshold_nn_metrics(sort, rec, s_threshold_miss, 'greater', metric_name="nn_miss_rate",
@@ -205,7 +205,7 @@ def test_thresh_d_primes():
                                                 seed=0)
     d_primes_thresh = .5
 
-    d_primes = compute_d_primes(sort, rec, apply_filter=False, seed=0)[0]
+    d_primes = compute_d_primes(sort, rec, apply_filter=False, seed=0)
     sort_d_primes = threshold_d_primes(sort, rec, d_primes_thresh, "less", apply_filter=False, seed=0)
 
     original_ids = sort.get_unit_ids()
@@ -223,7 +223,7 @@ def test_thresh_l_ratios():
                                                 seed=0)
     l_ratios_thresh = 0
 
-    l_ratios = compute_l_ratios(sort, rec, apply_filter=False, seed=0)[0]
+    l_ratios = compute_l_ratios(sort, rec, apply_filter=False, seed=0)
     sort_l_ratios = threshold_l_ratios(sort, rec, l_ratios_thresh, "less", apply_filter=False, seed=0)
 
     original_ids = sort.get_unit_ids()

--- a/spiketoolkit/tests/test_curation.py
+++ b/spiketoolkit/tests/test_curation.py
@@ -69,7 +69,7 @@ def test_thresh_presence_ratios():
     sort_pr = threshold_presence_ratios(sort, s_threshold, 'less', rec.get_num_frames())
     new_pr = compute_presence_ratios(sort_pr, sort.get_sampling_frequency())
 
-    assert np.all(new_pr >= s_threshold)
+    assert np.all(new_pr < s_threshold)
     check_dumping(sort_pr)
     shutil.rmtree('test')
 
@@ -141,8 +141,8 @@ def test_thresh_isolation_distances():
                                                 seed=0)
     s_threshold = 200
 
-    iso = compute_isolation_distances(sort, rec, apply_filter=False, seed=0)
-    sort_iso = threshold_isolation_distances(sort, rec, s_threshold, 'less', rec.get_num_frames(), apply_filter=False, seed=0)
+    iso = compute_isolation_distances(sort, rec,  apply_filter=False, seed=0)
+    sort_iso = threshold_isolation_distances(sort, rec, s_threshold, 'less', apply_filter=False, seed=0)
 
     original_ids = sort.get_unit_ids()
     new_iso = []
@@ -241,13 +241,13 @@ def test_curation_params():
 
 
 if __name__ == "__main__":
-    # test_thresh_num_spikes()
-    # test_thresh_presence_ratios()
-    # test_thresh_frs()
+    test_thresh_num_spikes()
+    test_thresh_presence_ratios()
+    test_thresh_frs()
     test_thresh_isi_violations()
 
-    # test_thresh_snrs()
-    # test_thresh_amplitude_cutoffs()
+    test_thresh_snrs()
+    test_thresh_amplitude_cutoffs()
 
     test_thresh_silhouettes()
     test_thresh_isolation_distances()

--- a/spiketoolkit/tests/test_validation.py
+++ b/spiketoolkit/tests/test_validation.py
@@ -2,41 +2,41 @@ import spikeextractors as se
 import numpy as np
 from spiketoolkit.validation import compute_isolation_distances, compute_isi_violations, compute_snrs, \
     compute_amplitude_cutoffs, compute_d_primes, compute_drift_metrics, compute_firing_rates, compute_l_ratios, \
-    compute_metrics, compute_nn_metrics, compute_num_spikes, compute_presence_ratios, compute_silhouette_scores, \
+    compute_quality_metrics, compute_nn_metrics, compute_num_spikes, compute_presence_ratios, compute_silhouette_scores, \
     get_validation_params
 
 
 def test_functions():
     rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4, seed=0)
 
-    firing_rates = compute_firing_rates(sort, seed=0)[0]
-    num_spikes = compute_num_spikes(sort, seed=0)[0]
-    isi = compute_isi_violations(sort, seed=0)[0]
-    presence = compute_presence_ratios(sort, seed=0)[0]
-    amp_cutoff = compute_amplitude_cutoffs(sort, rec, seed=0)[0]
-    max_drift, cum_drift = compute_drift_metrics(sort, rec, seed=0, memmap=False)[0]
-    silh = compute_silhouette_scores(sort, rec, seed=0)[0]
-    iso = compute_isolation_distances(sort, rec, seed=0)[0]
-    l_ratio = compute_l_ratios(sort, rec, seed=0)[0]
-    dprime = compute_d_primes(sort, rec, seed=0)[0]
-    nn_hit, nn_miss = compute_nn_metrics(sort, rec, seed=0)[0]
-    snr = compute_snrs(sort, rec, seed=0)[0]
-    metrics = compute_metrics(sort, rec, return_dict=True, seed=0)
+    firing_rates = compute_firing_rates(sort, rec.get_num_frames(), seed=0)
+    num_spikes = compute_num_spikes(sort, rec.get_num_frames(), seed=0)
+    isi = compute_isi_violations(sort, rec.get_num_frames(), seed=0)
+    presence = compute_presence_ratios(sort, rec.get_num_frames(), seed=0)
+    amp_cutoff = compute_amplitude_cutoffs(sort, rec, seed=0)
+    max_drift, cum_drift = compute_drift_metrics(sort, rec, seed=0, memmap=False)
+    silh = compute_silhouette_scores(sort, rec, seed=0)
+    iso = compute_isolation_distances(sort, rec, seed=0)
+    l_ratio = compute_l_ratios(sort, rec, seed=0)
+    dprime = compute_d_primes(sort, rec, seed=0)
+    nn_hit, nn_miss = compute_nn_metrics(sort, rec, seed=0)
+    snr = compute_snrs(sort, rec, seed=0)
+    metrics = compute_quality_metrics(sort, rec, return_dict=True, seed=0)
 
-    assert np.allclose(metrics['firing_rate'][0], firing_rates)
-    assert np.allclose(metrics['num_spikes'][0], num_spikes)
-    assert np.allclose(metrics['isi_viol'][0], isi)
-    assert np.allclose(metrics['amplitude_cutoff'][0], amp_cutoff)
-    assert np.allclose(metrics['presence_ratio'][0], presence)
-    assert np.allclose(metrics['silhouette_score'][0], silh)
-    assert np.allclose(metrics['isolation_distance'][0], iso)
-    assert np.allclose(metrics['l_ratio'][0], l_ratio)
-    assert np.allclose(metrics['d_prime'][0], dprime)
-    assert np.allclose(metrics['snr'][0], snr)
-    assert np.allclose(metrics['max_drift'][0], max_drift)
-    assert np.allclose(metrics['cumulative_drift'][0], cum_drift)
-    assert np.allclose(metrics['nn_hit_rate'][0], nn_hit)
-    assert np.allclose(metrics['nn_miss_rate'][0], nn_miss)
+    assert np.allclose(metrics['firing_rate'], firing_rates)
+    assert np.allclose(metrics['num_spikes'], num_spikes)
+    assert np.allclose(metrics['isi_viol'], isi)
+    assert np.allclose(metrics['amplitude_cutoff'], amp_cutoff)
+    assert np.allclose(metrics['presence_ratio'], presence)
+    assert np.allclose(metrics['silhouette_score'], silh)
+    assert np.allclose(metrics['isolation_distance'], iso)
+    assert np.allclose(metrics['l_ratio'], l_ratio)
+    assert np.allclose(metrics['d_prime'], dprime)
+    assert np.allclose(metrics['snr'], snr)
+    assert np.allclose(metrics['max_drift'], max_drift)
+    assert np.allclose(metrics['cumulative_drift'], cum_drift)
+    assert np.allclose(metrics['nn_hit_rate'], nn_hit)
+    assert np.allclose(metrics['nn_miss_rate'], nn_miss)
 
 
 def test_validation_params():

--- a/spiketoolkit/tests/test_validation.py
+++ b/spiketoolkit/tests/test_validation.py
@@ -10,7 +10,7 @@ def test_functions():
     rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4, seed=0)
 
     firing_rates = compute_firing_rates(sort, rec.get_num_frames(), seed=0)
-    num_spikes = compute_num_spikes(sort, rec.get_num_frames(), seed=0)
+    num_spikes = compute_num_spikes(sort, seed=0)
     isi = compute_isi_violations(sort, rec.get_num_frames(), seed=0)
     presence = compute_presence_ratios(sort, rec.get_num_frames(), seed=0)
     amp_cutoff = compute_amplitude_cutoffs(sort, rec, seed=0)

--- a/spiketoolkit/validation/quality_metric_classes/amplitude_cutoff.py
+++ b/spiketoolkit/validation/quality_metric_classes/amplitude_cutoff.py
@@ -20,27 +20,23 @@ class AmplitudeCutoff(QualityMetric):
     def compute_metric(self, **kwargs):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
-        amplitude_cutoffs_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times_amps)
-            amplitude_cutoffs_all = metrics.calculate_amplitude_cutoff(
-                self._metric_data._spike_clusters_amps[in_epoch],
-                self._metric_data._amplitudes[in_epoch],
-                self._metric_data._total_units,
-                verbose=self._metric_data.verbose,
-            )
-            amplitude_cutoffs_list = []
-            for i in self._metric_data._unit_indices:
-                amplitude_cutoffs_list.append(amplitude_cutoffs_all[i])
-            amplitude_cutoffs = np.asarray(amplitude_cutoffs_list)
-            amplitude_cutoffs_epochs.append(amplitude_cutoffs)
+        amplitude_cutoffs_all = metrics.calculate_amplitude_cutoff(
+            self._metric_data._spike_clusters_amps,
+            self._metric_data._amplitudes,
+            self._metric_data._total_units,
+            verbose=self._metric_data.verbose,
+        )
+        amplitude_cutoffs_list = []
+        for i in self._metric_data._unit_indices:
+            amplitude_cutoffs_list.append(amplitude_cutoffs_all[i])
+        amplitude_cutoffs = np.asarray(amplitude_cutoffs_list)
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, amplitude_cutoffs_epochs, self._metric_name)
-        return amplitude_cutoffs_epochs
+            self.save_property_or_features(self._metric_data._sorting, amplitude_cutoffs, self._metric_name)
+        return amplitude_cutoffs
 
     def threshold_metric(self, threshold, threshold_sign, **kwargs):
-        amplitude_cutoff_epochs = self.compute_metric(**kwargs)[0]
+        amplitude_cutoffs = self.compute_metric(**kwargs)
         threshold_curator = ThresholdCurator(sorting=self._metric_data._sorting,
-                                             metrics_epoch=amplitude_cutoff_epochs)
+                                             metric=amplitude_cutoffs)
         threshold_curator.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
         return threshold_curator

--- a/spiketoolkit/validation/quality_metric_classes/d_prime.py
+++ b/spiketoolkit/validation/quality_metric_classes/d_prime.py
@@ -22,37 +22,32 @@ class DPrime(QualityMetric):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         seed = params_dict['seed']
         save_property_or_features = params_dict['save_property_or_features']
-
-        d_primes_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times_pca)
-            d_primes_all = metrics.calculate_pc_metrics(
-                spike_clusters=self._metric_data._spike_clusters_pca[in_epoch],
-                total_units=self._metric_data._total_units,
-                pc_features=self._metric_data._pc_features[in_epoch, :, :],
-                pc_feature_ind=self._metric_data._pc_feature_ind,
-                num_channels_to_compare=num_channels_to_compare,
-                max_spikes_for_cluster=max_spikes_per_cluster,
-                spikes_for_nn=None,
-                n_neighbors=None,
-                metric_names=["d_prime"],
-                seed=seed,
-                verbose=self._metric_data.verbose,
-            )[2]
-            d_primes_list = []
-            for i in self._metric_data._unit_indices:
-                d_primes_list.append(d_primes_all[i])
-            d_primes = np.asarray(d_primes_list)
-            d_primes_epochs.append(d_primes)
+        d_primes_all = metrics.calculate_pc_metrics(
+            spike_clusters=self._metric_data._spike_clusters_pca,
+            total_units=self._metric_data._total_units,
+            pc_features=self._metric_data._pc_features,
+            pc_feature_ind=self._metric_data._pc_feature_ind,
+            num_channels_to_compare=num_channels_to_compare,
+            max_spikes_for_cluster=max_spikes_per_cluster,
+            spikes_for_nn=None,
+            n_neighbors=None,
+            metric_names=["d_prime"],
+            seed=seed,
+            verbose=self._metric_data.verbose,
+        )[2]
+        d_primes_list = []
+        for i in self._metric_data._unit_indices:
+            d_primes_list.append(d_primes_all[i])
+        d_primes = np.asarray(d_primes_list)
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, d_primes_epochs, self._metric_name)
-        return d_primes_epochs
+            self.save_property_or_features(self._metric_data._sorting, d_primes, self._metric_name)
+        return d_primes
 
     def threshold_metric(self, threshold, threshold_sign, num_channels_to_compare, max_spikes_per_cluster, **kwargs):
-        d_primes_epochs = \
-        self.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)[0]
+        d_primes = \
+        self.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
         threshold_curator = ThresholdCurator(
-            sorting=self._metric_data._sorting, metrics_epoch=d_primes_epochs
+            sorting=self._metric_data._sorting, metric=d_primes
         )
         threshold_curator.threshold_sorting(
             threshold=threshold, threshold_sign=threshold_sign

--- a/spiketoolkit/validation/quality_metric_classes/drift_metric.py
+++ b/spiketoolkit/validation/quality_metric_classes/drift_metric.py
@@ -20,48 +20,42 @@ class DriftMetric(QualityMetric):
     def compute_metric(self, drift_metrics_interval_s, drift_metrics_min_spikes_per_interval, **kwargs):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
-        max_drifts_epochs = []
-        cumulative_drifts_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times_pca)
-            max_drifts_all, cumulative_drifts_all = metrics.calculate_drift_metrics(
-                self._metric_data._spike_times_pca[in_epoch],
-                self._metric_data._spike_clusters_pca[in_epoch],
-                self._metric_data._total_units,
-                self._metric_data._pc_features[in_epoch, :, :],
-                self._metric_data._pc_feature_ind,
-                drift_metrics_interval_s,
-                drift_metrics_min_spikes_per_interval,
-                verbose=self._metric_data.verbose,
-            )
-            max_drifts_list = []
-            cumulative_drifts_list = []
-            for i in self._metric_data._unit_indices:
-                max_drifts_list.append(max_drifts_all[i])
-                cumulative_drifts_list.append(cumulative_drifts_all[i])
-            max_drifts = np.asarray(max_drifts_list)
-            cumulative_drifts = np.asarray(cumulative_drifts_list)
-            max_drifts_epochs.append(max_drifts)
-            cumulative_drifts_epochs.append(cumulative_drifts)
+        max_drifts_all, cumulative_drifts_all = metrics.calculate_drift_metrics(
+            self._metric_data._spike_times_pca,
+            self._metric_data._spike_clusters_pca,
+            self._metric_data._total_units,
+            self._metric_data._pc_features,
+            self._metric_data._pc_feature_ind,
+            drift_metrics_interval_s,
+            drift_metrics_min_spikes_per_interval,
+            verbose=self._metric_data.verbose,
+        )
+        max_drifts_list = []
+        cumulative_drifts_list = []
+        for i in self._metric_data._unit_indices:
+            max_drifts_list.append(max_drifts_all[i])
+            cumulative_drifts_list.append(cumulative_drifts_all[i])
+        max_drifts = np.asarray(max_drifts_list)
+        cumulative_drifts = np.asarray(cumulative_drifts_list)
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, max_drifts_epochs, metric_name="max_drift")
-            self.save_property_or_features(self._metric_data._sorting, cumulative_drifts_epochs, metric_name="cumulative_drift")
-        return list(zip(max_drifts_epochs, cumulative_drifts_epochs))
+            self.save_property_or_features(self._metric_data._sorting, max_drifts, metric_name="max_drift")
+            self.save_property_or_features(self._metric_data._sorting, cumulative_drifts, metric_name="cumulative_drift")
+        return [max_drifts, cumulative_drifts]
 
     def threshold_metric(self, threshold, threshold_sign, metric_name, drift_metrics_interval_s,
                          drift_metrics_min_spikes_per_interval, **kwargs):
-        max_drifts_epochs, cumulative_drifts_epochs = \
+        max_drifts, cumulative_drifts = \
         self.compute_metric(drift_metrics_interval_s, drift_metrics_min_spikes_per_interval,
-                            **kwargs)[0]
+                            **kwargs)
         if metric_name == "max_drift":
-            metrics_epoch = max_drifts_epochs
+            metric = max_drifts
         elif metric_name == "cumulative_drift":
-            metrics_epoch = cumulative_drifts_epochs
+            metric = cumulative_drifts
         else:
             raise ValueError("Invalid metric named entered")
 
         threshold_curator = ThresholdCurator(
-            sorting=self._metric_data._sorting, metrics_epoch=metrics_epoch
+            sorting=self._metric_data._sorting, metric=metric
         )
         threshold_curator.threshold_sorting(
             threshold=threshold, threshold_sign=threshold_sign

--- a/spiketoolkit/validation/quality_metric_classes/firing_rate.py
+++ b/spiketoolkit/validation/quality_metric_classes/firing_rate.py
@@ -21,26 +21,22 @@ class FiringRate(QualityMetric):
     def compute_metric(self, **kwargs):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
-        firing_rate_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times)
-            firing_rate_all, _ = metrics.calculate_firing_rate_and_spikes(
-                self._metric_data._spike_times[in_epoch],
-                self._metric_data._spike_clusters[in_epoch],
-                self._metric_data._total_units,
-                verbose=self._metric_data.verbose,
-            )
-            firing_rate_list = []
-            for i in self._metric_data._unit_indices:
-                firing_rate_list.append(firing_rate_all[i])
-            firing_rate = np.asarray(firing_rate_list)
-            firing_rate_epochs.append(firing_rate)
+        firing_rate_all, _ = metrics.calculate_firing_rate_and_spikes(
+            self._metric_data._spike_times,
+            self._metric_data._spike_clusters,
+            self._metric_data._total_units,
+            verbose=self._metric_data.verbose,
+        )
+        firing_rate_list = []
+        for i in self._metric_data._unit_indices:
+            firing_rate_list.append(firing_rate_all[i])
+        firing_rate = np.asarray(firing_rate_list)
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, firing_rate_epochs, self._metric_name)
-        return firing_rate_epochs
+            self.save_property_or_features(self._metric_data._sorting, firing_rate, self._metric_name)
+        return firing_rate
 
     def threshold_metric(self, threshold, threshold_sign, **kwargs):
-        firing_rate_epochs = self.compute_metric(**kwargs)[0]
-        threshold_curator = ThresholdCurator(sorting=self._metric_data._sorting, metrics_epoch=firing_rate_epochs)
+        firing_rate = self.compute_metric(**kwargs)
+        threshold_curator = ThresholdCurator(sorting=self._metric_data._sorting, metric=firing_rate)
         threshold_curator.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
         return threshold_curator

--- a/spiketoolkit/validation/quality_metric_classes/firing_rate.py
+++ b/spiketoolkit/validation/quality_metric_classes/firing_rate.py
@@ -21,7 +21,7 @@ class FiringRate(QualityMetric):
     def compute_metric(self, **kwargs):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
-        firing_rate_all, _ = metrics.calculate_firing_rate_and_spikes(
+        firing_rate_all = metrics.calculate_firing_rates(
             self._metric_data._spike_times,
             self._metric_data._spike_clusters,
             self._metric_data._total_units,

--- a/spiketoolkit/validation/quality_metric_classes/firing_rate.py
+++ b/spiketoolkit/validation/quality_metric_classes/firing_rate.py
@@ -25,7 +25,7 @@ class FiringRate(QualityMetric):
             self._metric_data._spike_times,
             self._metric_data._spike_clusters,
             self._metric_data._total_units,
-            duration=self._metric_data._duration,
+            duration=self._metric_data._duration_in_frames/self._metric_data._sampling_frequency,
             verbose=self._metric_data.verbose,
         )
         firing_rate_list = []

--- a/spiketoolkit/validation/quality_metric_classes/firing_rate.py
+++ b/spiketoolkit/validation/quality_metric_classes/firing_rate.py
@@ -25,6 +25,7 @@ class FiringRate(QualityMetric):
             self._metric_data._spike_times,
             self._metric_data._spike_clusters,
             self._metric_data._total_units,
+            duration=self._metric_data._duration,
             verbose=self._metric_data.verbose,
         )
         firing_rate_list = []

--- a/spiketoolkit/validation/quality_metric_classes/isi_violation.py
+++ b/spiketoolkit/validation/quality_metric_classes/isi_violation.py
@@ -27,7 +27,7 @@ class ISIViolation(QualityMetric):
             self._metric_data._total_units,
             isi_threshold=isi_threshold,
             min_isi=min_isi,
-            duration=self._metric_data._duration,
+            duration=self._metric_data._duration_in_frames/self._metric_data._sampling_frequency,
             verbose=self._metric_data.verbose,
         )
         isi_violation_list = []

--- a/spiketoolkit/validation/quality_metric_classes/isi_violation.py
+++ b/spiketoolkit/validation/quality_metric_classes/isi_violation.py
@@ -27,6 +27,7 @@ class ISIViolation(QualityMetric):
             self._metric_data._total_units,
             isi_threshold=isi_threshold,
             min_isi=min_isi,
+            duration=self._metric_data._duration,
             verbose=self._metric_data.verbose,
         )
         isi_violation_list = []

--- a/spiketoolkit/validation/quality_metric_classes/isi_violation.py
+++ b/spiketoolkit/validation/quality_metric_classes/isi_violation.py
@@ -21,28 +21,24 @@ class ISIViolation(QualityMetric):
     def compute_metric(self, isi_threshold, min_isi, **kwargs):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
-        isi_violation_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times)
-            isi_violation_all = metrics.calculate_isi_violations(
-                self._metric_data._spike_times[in_epoch],
-                self._metric_data._spike_clusters[in_epoch],
-                self._metric_data._total_units,
-                isi_threshold=isi_threshold,
-                min_isi=min_isi,
-                verbose=self._metric_data.verbose,
-            )
-            isi_violation_list = []
-            for i in self._metric_data._unit_indices:
-                isi_violation_list.append(isi_violation_all[i])
-            isi_violation = np.asarray(isi_violation_list)
-            isi_violation_epochs.append(isi_violation)
+        isi_violation_all = metrics.calculate_isi_violations(
+            self._metric_data._spike_times,
+            self._metric_data._spike_clusters,
+            self._metric_data._total_units,
+            isi_threshold=isi_threshold,
+            min_isi=min_isi,
+            verbose=self._metric_data.verbose,
+        )
+        isi_violation_list = []
+        for i in self._metric_data._unit_indices:
+            isi_violation_list.append(isi_violation_all[i])
+        isi_violations = np.asarray(isi_violation_list)
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, isi_violation_epochs, self._metric_name)
-        return isi_violation_epochs
+            self.save_property_or_features(self._metric_data._sorting, isi_violations, self._metric_name)
+        return isi_violations
 
     def threshold_metric(self, threshold, threshold_sign, isi_threshold, min_isi, **kwargs):
-        isi_violation_epochs = self.compute_metric(isi_threshold, min_isi, **kwargs)[0]
-        threshold_curator = ThresholdCurator(sorting=self._metric_data._sorting, metrics_epoch=isi_violation_epochs)
+        isi_violations = self.compute_metric(isi_threshold, min_isi, **kwargs)
+        threshold_curator = ThresholdCurator(sorting=self._metric_data._sorting, metric=isi_violations)
         threshold_curator.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
         return threshold_curator

--- a/spiketoolkit/validation/quality_metric_classes/isolation_distance.py
+++ b/spiketoolkit/validation/quality_metric_classes/isolation_distance.py
@@ -22,37 +22,32 @@ class IsolationDistance(QualityMetric):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
         seed = params_dict['seed']
-
-        isolation_distances_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times_pca)
-            isolation_distances_all = metrics.calculate_pc_metrics(
-                spike_clusters=self._metric_data._spike_clusters_pca[in_epoch],
-                total_units=self._metric_data._total_units,
-                pc_features=self._metric_data._pc_features[in_epoch, :, :],
-                pc_feature_ind=self._metric_data._pc_feature_ind,
-                num_channels_to_compare=num_channels_to_compare,
-                max_spikes_for_cluster=max_spikes_per_cluster,
-                spikes_for_nn=None,
-                n_neighbors=None,
-                metric_names=["isolation_distance"],
-                seed=seed,
-                verbose=self._metric_data.verbose,
-            )[0]
-            isolation_distances_list = []
-            for i in self._metric_data._unit_indices:
-                isolation_distances_list.append(isolation_distances_all[i])
-            isolation_distances = np.asarray(isolation_distances_list)
-            isolation_distances_epochs.append(isolation_distances)
+        isolation_distances_all = metrics.calculate_pc_metrics(
+            spike_clusters=self._metric_data._spike_clusters_pca,
+            total_units=self._metric_data._total_units,
+            pc_features=self._metric_data._pc_features,
+            pc_feature_ind=self._metric_data._pc_feature_ind,
+            num_channels_to_compare=num_channels_to_compare,
+            max_spikes_for_cluster=max_spikes_per_cluster,
+            spikes_for_nn=None,
+            n_neighbors=None,
+            metric_names=["isolation_distance"],
+            seed=seed,
+            verbose=self._metric_data.verbose,
+        )[0]
+        isolation_distances_list = []
+        for i in self._metric_data._unit_indices:
+            isolation_distances_list.append(isolation_distances_all[i])
+        isolation_distances = np.asarray(isolation_distances_list)
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, isolation_distances_epochs, self._metric_name)
-        return isolation_distances_epochs
+            self.save_property_or_features(self._metric_data._sorting, isolation_distances, self._metric_name)
+        return isolation_distances
 
     def threshold_metric(self, threshold, threshold_sign, num_channels_to_compare, max_spikes_per_cluster, **kwargs):
-        isolation_distances_epochs = \
-        self.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)[0]
+        isolation_distances = \
+        self.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
         threshold_curator = ThresholdCurator(
-            sorting=self._metric_data._sorting, metrics_epoch=isolation_distances_epochs
+            sorting=self._metric_data._sorting, metric=isolation_distances
         )
         threshold_curator.threshold_sorting(
             threshold=threshold, threshold_sign=threshold_sign

--- a/spiketoolkit/validation/quality_metric_classes/l_ratio.py
+++ b/spiketoolkit/validation/quality_metric_classes/l_ratio.py
@@ -22,37 +22,32 @@ class LRatio(QualityMetric):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
         seed = params_dict['seed']
-
-        l_ratios_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times_pca)
-            l_ratios_all = metrics.calculate_pc_metrics(
-                spike_clusters=self._metric_data._spike_clusters_pca[in_epoch],
-                total_units=self._metric_data._total_units,
-                pc_features=self._metric_data._pc_features[in_epoch, :, :],
-                pc_feature_ind=self._metric_data._pc_feature_ind,
-                num_channels_to_compare=num_channels_to_compare,
-                max_spikes_for_cluster=max_spikes_per_cluster,
-                spikes_for_nn=None,
-                n_neighbors=None,
-                metric_names=["l_ratio"],
-                seed=seed,
-                verbose=self._metric_data.verbose,
-            )[1]
-            l_ratios_list = []
-            for i in self._metric_data._unit_indices:
-                l_ratios_list.append(l_ratios_all[i])
-            l_ratios = np.asarray(l_ratios_list)
-            l_ratios_epochs.append(l_ratios)
+        l_ratios_all = metrics.calculate_pc_metrics(
+            spike_clusters=self._metric_data._spike_clusters_pca,
+            total_units=self._metric_data._total_units,
+            pc_features=self._metric_data._pc_features,
+            pc_feature_ind=self._metric_data._pc_feature_ind,
+            num_channels_to_compare=num_channels_to_compare,
+            max_spikes_for_cluster=max_spikes_per_cluster,
+            spikes_for_nn=None,
+            n_neighbors=None,
+            metric_names=["l_ratio"],
+            seed=seed,
+            verbose=self._metric_data.verbose,
+        )[1]
+        l_ratios_list = []
+        for i in self._metric_data._unit_indices:
+            l_ratios_list.append(l_ratios_all[i])
+        l_ratios = np.asarray(l_ratios_list)
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, l_ratios_epochs, self._metric_name)
-        return l_ratios_epochs
+            self.save_property_or_features(self._metric_data._sorting, l_ratios, self._metric_name)
+        return l_ratios
 
     def threshold_metric(self, threshold, threshold_sign, num_channels_to_compare, max_spikes_per_cluster, **kwargs):
-        l_ratios_epochs = \
-        self.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)[0]
+        l_ratios = \
+        self.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
         threshold_curator = ThresholdCurator(
-            sorting=self._metric_data._sorting, metrics_epoch=l_ratios_epochs
+            sorting=self._metric_data._sorting, metric=l_ratios
         )
         threshold_curator.threshold_sorting(
             threshold=threshold, threshold_sign=threshold_sign

--- a/spiketoolkit/validation/quality_metric_classes/metric_data.py
+++ b/spiketoolkit/validation/quality_metric_classes/metric_data.py
@@ -19,7 +19,7 @@ class MetricData:
         self,
         sorting,
         recording,
-        duration,
+        duration_in_frames,
         sampling_frequency,
         apply_filter,
         freq_min,
@@ -36,8 +36,8 @@ class MetricData:
             The sorting extractor to be evaluated.
         recording: RecordingExtractor
             The recording extractor to be stored. If None, the recording extractor can be added later.
-        duration: int
-            Length of recording (in frames). If None, will look to recording extractor for duration.
+        duration_in_frames: int
+            Length of recording (in frames). If None, will look to recording extractor for num frames.
         sampling_frequency:
             The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor.
         apply_filter: bool
@@ -108,10 +108,10 @@ class MetricData:
                 freq_min=freq_min,
                 freq_max=freq_max,
             )
-            self._duration = recording.get_num_frames()
+            self._duration_in_frames = recording.get_num_frames()
         else:
             self._recording = None
-            self._duration = duration
+            self._duration_in_frames = duration_in_frames
 
     def set_recording(self, recording, apply_filter, freq_min, freq_max):
         """

--- a/spiketoolkit/validation/quality_metric_classes/metric_data.py
+++ b/spiketoolkit/validation/quality_metric_classes/metric_data.py
@@ -37,7 +37,7 @@ class MetricData:
         recording: RecordingExtractor
             The recording extractor to be stored. If None, the recording extractor can be added later.
         duration: int
-            Length of recording (in frames).
+            Length of recording (in frames). If None, will look to recording extractor for duration.
         sampling_frequency:
             The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor.
         apply_filter: bool
@@ -111,12 +111,7 @@ class MetricData:
             self._duration = recording.get_num_frames()
         else:
             self._recording = None
-            if duration is None:
-                raise ValueError(
-                "Please pass in a sampling frequency (your SortingExtractor does not have one specified and no RecordingExtractor given)."
-                )
-            else:
-                self._duration = duration = duration
+            self._duration = duration
 
     def set_recording(self, recording, apply_filter, freq_min, freq_max):
         """

--- a/spiketoolkit/validation/quality_metric_classes/metric_data.py
+++ b/spiketoolkit/validation/quality_metric_classes/metric_data.py
@@ -19,6 +19,7 @@ class MetricData:
         self,
         sorting,
         recording,
+        duration,
         sampling_frequency,
         apply_filter,
         freq_min,
@@ -35,6 +36,8 @@ class MetricData:
             The sorting extractor to be evaluated.
         recording: RecordingExtractor
             The recording extractor to be stored. If None, the recording extractor can be added later.
+        duration: int
+            Length of recording (in frames).
         sampling_frequency:
             The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor.
         apply_filter: bool
@@ -105,8 +108,15 @@ class MetricData:
                 freq_min=freq_min,
                 freq_max=freq_max,
             )
+            self._duration = recording.get_num_frames()
         else:
             self._recording = None
+            if duration is None:
+                raise ValueError(
+                "Please pass in a sampling frequency (your SortingExtractor does not have one specified and no RecordingExtractor given)."
+                )
+            else:
+                self._duration = duration = duration
 
     def set_recording(self, recording, apply_filter, freq_min, freq_max):
         """

--- a/spiketoolkit/validation/quality_metric_classes/nearest_neighbor.py
+++ b/spiketoolkit/validation/quality_metric_classes/nearest_neighbor.py
@@ -25,54 +25,47 @@ class NearestNeighbor(QualityMetric):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
         seed = params_dict['seed']
-
-        nn_hit_rates_epochs = []
-        nn_miss_rates_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times_pca)
-            spikes_in_epoch = np.sum(in_epoch)
-            spikes_for_nn = np.min([spikes_in_epoch, max_spikes_for_nn])
-            nn_hit_rates_all, nn_miss_rates_all = metrics.calculate_pc_metrics(
-                spike_clusters=self._metric_data._spike_clusters_pca[in_epoch],
-                total_units=self._metric_data._total_units,
-                pc_features=self._metric_data._pc_features[in_epoch, :, :],
-                pc_feature_ind=self._metric_data._pc_feature_ind,
-                num_channels_to_compare=num_channels_to_compare,
-                max_spikes_for_cluster=max_spikes_per_cluster,
-                spikes_for_nn=spikes_for_nn,
-                n_neighbors=n_neighbors,
-                metric_names=["nearest_neighbor"],
-                seed=seed,
-                verbose=self._metric_data.verbose,
-            )[3:5]
-            nn_hit_rates_list = []
-            nn_miss_rates_list = []
-            for i in self._metric_data._unit_indices:
-                nn_hit_rates_list.append(nn_hit_rates_all[i])
-                nn_miss_rates_list.append(nn_miss_rates_all[i])
-            nn_hit_rates = np.asarray(nn_hit_rates_list)
-            nn_miss_rates = np.asarray(nn_miss_rates_list)
-            nn_hit_rates_epochs.append(nn_hit_rates)
-            nn_miss_rates_epochs.append(nn_miss_rates)
+        total_spikes = self._metric_data._spike_clusters_pca.shape[0]
+        spikes_for_nn = np.min([total_spikes, max_spikes_for_nn])
+        nn_hit_rates_all, nn_miss_rates_all = metrics.calculate_pc_metrics(
+            spike_clusters=self._metric_data._spike_clusters_pca,
+            total_units=self._metric_data._total_units,
+            pc_features=self._metric_data._pc_features,
+            pc_feature_ind=self._metric_data._pc_feature_ind,
+            num_channels_to_compare=num_channels_to_compare,
+            max_spikes_for_cluster=max_spikes_per_cluster,
+            spikes_for_nn=spikes_for_nn,
+            n_neighbors=n_neighbors,
+            metric_names=["nearest_neighbor"],
+            seed=seed,
+            verbose=self._metric_data.verbose,
+        )[3:5]
+        nn_hit_rates_list = []
+        nn_miss_rates_list = []
+        for i in self._metric_data._unit_indices:
+            nn_hit_rates_list.append(nn_hit_rates_all[i])
+            nn_miss_rates_list.append(nn_miss_rates_all[i])
+        nn_hit_rates = np.asarray(nn_hit_rates_list)
+        nn_miss_rates = np.asarray(nn_miss_rates_list)
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, nn_hit_rates_epochs, metric_name="nn_hit_rate")
-            self.save_property_or_features(self._metric_data._sorting, nn_miss_rates_epochs, metric_name="nn_miss_rate")
-        return list(zip(nn_hit_rates_epochs, nn_miss_rates_epochs))
+            self.save_property_or_features(self._metric_data._sorting, nn_hit_rates, metric_name="nn_hit_rate")
+            self.save_property_or_features(self._metric_data._sorting, nn_miss_rates, metric_name="nn_miss_rate")
+        return [nn_hit_rates_list, nn_miss_rates]
 
     def threshold_metric(self, threshold, threshold_sign, metric_name, num_channels_to_compare, max_spikes_per_cluster,
                          max_spikes_for_nn, n_neighbors, **kwargs):
-        nn_hit_rates_epochs, nn_miss_rates_epochs = \
+        nn_hit_rates, nn_miss_rates = \
         self.compute_metric(num_channels_to_compare, max_spikes_per_cluster, max_spikes_for_nn,
-                            n_neighbors, **kwargs)[0]
+                            n_neighbors, **kwargs)
         if metric_name == "nn_hit_rate":
-            metrics_epoch = nn_hit_rates_epochs
+            metric = nn_hit_rates
         elif metric_name == "nn_miss_rate":
-            metrics_epoch = nn_miss_rates_epochs
+            metric = nn_miss_rates
         else:
             raise ValueError("Invalid metric named entered")
 
         threshold_curator = ThresholdCurator(
-            sorting=self._metric_data._sorting, metrics_epoch=metrics_epoch
+            sorting=self._metric_data._sorting, metric=metric
         )
         threshold_curator.threshold_sorting(
             threshold=threshold, threshold_sign=threshold_sign

--- a/spiketoolkit/validation/quality_metric_classes/num_spikes.py
+++ b/spiketoolkit/validation/quality_metric_classes/num_spikes.py
@@ -25,6 +25,7 @@ class NumSpikes(QualityMetric):
             self._metric_data._spike_times,
             self._metric_data._spike_clusters,
             self._metric_data._total_units,
+            duration=self._metric_data._duration,
             verbose=self._metric_data.verbose,
         )
         num_spikes_list = []

--- a/spiketoolkit/validation/quality_metric_classes/num_spikes.py
+++ b/spiketoolkit/validation/quality_metric_classes/num_spikes.py
@@ -21,27 +21,22 @@ class NumSpikes(QualityMetric):
     def compute_metric(self, **kwargs):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
-
-        num_spikes_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times)
-            _, num_spikes_all = metrics.calculate_firing_rate_and_spikes(
-                self._metric_data._spike_times[in_epoch],
-                self._metric_data._spike_clusters[in_epoch],
-                self._metric_data._total_units,
-                verbose=self._metric_data.verbose,
-            )
-            num_spikes_list = []
-            for i in self._metric_data._unit_indices:
-                num_spikes_list.append(num_spikes_all[i])
-            num_spikes = np.asarray(num_spikes_list).astype('int')
-            num_spikes_epochs.append(num_spikes)
+        _, num_spikes_all = metrics.calculate_firing_rate_and_spikes(
+            self._metric_data._spike_times,
+            self._metric_data._spike_clusters,
+            self._metric_data._total_units,
+            verbose=self._metric_data.verbose,
+        )
+        num_spikes_list = []
+        for i in self._metric_data._unit_indices:
+            num_spikes_list.append(num_spikes_all[i])
+        num_spikes = np.asarray(num_spikes_list).astype('int')
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, num_spikes_epochs, self._metric_name)
-        return num_spikes_epochs
+            self.save_property_or_features(self._metric_data._sorting, num_spikes, self._metric_name)
+        return num_spikes
 
     def threshold_metric(self, threshold, threshold_sign, **kwargs):
-        num_spikes_epochs = self.compute_metric(**kwargs)[0]
-        threshold_curator = ThresholdCurator(sorting=self._metric_data._sorting, metrics_epoch=num_spikes_epochs)
+        num_spikes = self.compute_metric(**kwargs)
+        threshold_curator = ThresholdCurator(sorting=self._metric_data._sorting, metric=num_spikes)
         threshold_curator.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
         return threshold_curator

--- a/spiketoolkit/validation/quality_metric_classes/num_spikes.py
+++ b/spiketoolkit/validation/quality_metric_classes/num_spikes.py
@@ -21,11 +21,10 @@ class NumSpikes(QualityMetric):
     def compute_metric(self, **kwargs):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
-        _, num_spikes_all = metrics.calculate_firing_rate_and_spikes(
+        num_spikes_all = metrics.calculate_num_spikes(
             self._metric_data._spike_times,
             self._metric_data._spike_clusters,
             self._metric_data._total_units,
-            duration=self._metric_data._duration,
             verbose=self._metric_data.verbose,
         )
         num_spikes_list = []

--- a/spiketoolkit/validation/quality_metric_classes/parameter_dictionaries.py
+++ b/spiketoolkit/validation/quality_metric_classes/parameter_dictionaries.py
@@ -5,16 +5,8 @@ import numpy as np
 
 recording_params_dict = OrderedDict([('apply_filter', True), ('freq_min', 300.0), ('freq_max', 6000.0)])
 
-epoch_params_dict = OrderedDict([('epoch_tuples', None), ('epoch_names', None)])
-
-
 def get_recording_params():
     return recording_params_dict.copy()
-
-
-def get_epoch_params():
-    return epoch_params_dict.copy()
-
 
 def get_validation_params():
     '''
@@ -30,7 +22,6 @@ def get_validation_params():
     all_params.update(get_waveforms_params())
     all_params.update(get_amplitudes_params())
     all_params.update(get_pca_params())
-    all_params.update(get_epoch_params())
     all_params.update(get_common_params())
 
     return all_params

--- a/spiketoolkit/validation/quality_metric_classes/presence_ratio.py
+++ b/spiketoolkit/validation/quality_metric_classes/presence_ratio.py
@@ -21,27 +21,22 @@ class PresenceRatio(QualityMetric):
     def compute_metric(self, **kwargs):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
-
-        presence_ratios_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times)
-            presence_ratios_all = metrics.calculate_presence_ratio(
-                self._metric_data._spike_times[in_epoch],
-                self._metric_data._spike_clusters[in_epoch],
-                self._metric_data._total_units,
-                verbose=self._metric_data.verbose,
-            )
-            presence_ratios_list = []
-            for i in self._metric_data._unit_indices:
-                presence_ratios_list.append(presence_ratios_all[i])
-            presence_ratios = np.asarray(presence_ratios_list)
-            presence_ratios_epochs.append(presence_ratios)
+        presence_ratios_all = metrics.calculate_presence_ratio(
+            self._metric_data._spike_times,
+            self._metric_data._spike_clusters,
+            self._metric_data._total_units,
+            verbose=self._metric_data.verbose,
+        )
+        presence_ratios_list = []
+        for i in self._metric_data._unit_indices:
+            presence_ratios_list.append(presence_ratios_all[i])
+        presence_ratios = np.asarray(presence_ratios_list)
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, presence_ratios_epochs, self._metric_name)
-        return presence_ratios_epochs
+            self.save_property_or_features(self._metric_data._sorting, presence_ratios, self._metric_name)
+        return presence_ratios
 
     def threshold_metric(self, threshold, threshold_sign, **kwargs):
-        presence_ratios_epochs = self.compute_metric(**kwargs)[0]
-        threshold_curator = ThresholdCurator(sorting=self._metric_data._sorting, metrics_epoch=presence_ratios_epochs)
+        presence_ratios = self.compute_metric(**kwargs)
+        threshold_curator = ThresholdCurator(sorting=self._metric_data._sorting, metric=presence_ratios)
         threshold_curator.threshold_sorting(threshold=threshold, threshold_sign=threshold_sign)
         return threshold_curator

--- a/spiketoolkit/validation/quality_metric_classes/presence_ratio.py
+++ b/spiketoolkit/validation/quality_metric_classes/presence_ratio.py
@@ -25,6 +25,7 @@ class PresenceRatio(QualityMetric):
             self._metric_data._spike_times,
             self._metric_data._spike_clusters,
             self._metric_data._total_units,
+            duration=self._metric_data._duration,
             verbose=self._metric_data.verbose,
         )
         presence_ratios_list = []

--- a/spiketoolkit/validation/quality_metric_classes/presence_ratio.py
+++ b/spiketoolkit/validation/quality_metric_classes/presence_ratio.py
@@ -25,7 +25,7 @@ class PresenceRatio(QualityMetric):
             self._metric_data._spike_times,
             self._metric_data._spike_clusters,
             self._metric_data._total_units,
-            duration=self._metric_data._duration,
+            duration=self._metric_data._duration_in_frames/self._metric_data._sampling_frequency,
             verbose=self._metric_data.verbose,
         )
         presence_ratios_list = []

--- a/spiketoolkit/validation/quality_metric_classes/quality_metric.py
+++ b/spiketoolkit/validation/quality_metric_classes/quality_metric.py
@@ -42,10 +42,6 @@ class QualityMetric(ABC):
         '''
         pass
 
-    def save_property_or_features(self, sorting, metric_epochs, metric_name):
-        if len(self._metric_data.get_epochs()) == 1:
-            metric = metric_epochs[0]
-            for i_u, u in enumerate(self._metric_data._unit_ids):
-                sorting.set_unit_property(u, metric_name, metric[i_u])
-        else:
-            pass
+    def save_property_or_features(self, sorting, metric, metric_name):
+        for i_u, u in enumerate(self._metric_data._unit_ids):
+            sorting.set_unit_property(u, metric_name, metric[i_u])

--- a/spiketoolkit/validation/quality_metric_classes/silhouette_score.py
+++ b/spiketoolkit/validation/quality_metric_classes/silhouette_score.py
@@ -22,36 +22,30 @@ class SilhouetteScore(QualityMetric):
         params_dict = update_all_param_dicts_with_kwargs(kwargs)
         save_property_or_features = params_dict['save_property_or_features']
         seed = params_dict['seed']
-
-        silhouette_scores_epochs = []
-        for epoch in self._metric_data._epochs:
-            in_epoch = self._metric_data.get_in_epoch_bool_mask(epoch, self._metric_data._spike_times_pca)
-            spikes_in_epoch = np.sum(in_epoch)
-            spikes_for_silhouette = np.min([spikes_in_epoch, max_spikes_for_silhouette])
-
-            silhouette_scores_all = metrics.calculate_silhouette_score(
-                self._metric_data._spike_clusters_pca[in_epoch],
-                self._metric_data._total_units,
-                self._metric_data._pc_features[in_epoch, :, :],
-                self._metric_data._pc_feature_ind,
-                spikes_for_silhouette,
-                seed=seed,
-                verbose=self._metric_data.verbose,
-            )
-            silhouette_scores_list = []
-            for index in self._metric_data._unit_indices:
-                silhouette_scores_list.append(silhouette_scores_all[index])
-            silhouette_scores = np.asarray(silhouette_scores_list)
-            silhouette_scores_epochs.append(silhouette_scores)
+        total_spikes = self._metric_data._spike_clusters_pca.shape[0]
+        spikes_for_silhouette = np.min([total_spikes, max_spikes_for_silhouette])
+        silhouette_scores_all = metrics.calculate_silhouette_score(
+            self._metric_data._spike_clusters_pca,
+            self._metric_data._total_units,
+            self._metric_data._pc_features,
+            self._metric_data._pc_feature_ind,
+            spikes_for_silhouette,
+            seed=seed,
+            verbose=self._metric_data.verbose,
+        )
+        silhouette_scores_list = []
+        for index in self._metric_data._unit_indices:
+            silhouette_scores_list.append(silhouette_scores_all[index])
+        silhouette_scores = np.asarray(silhouette_scores_list)
         if save_property_or_features:
-            self.save_property_or_features(self._metric_data._sorting, silhouette_scores_epochs, self._metric_name)
-        return silhouette_scores_epochs
+            self.save_property_or_features(self._metric_data._sorting, silhouette_scores, self._metric_name)
+        return silhouette_scores
 
     def threshold_metric(self, threshold, threshold_sign, max_spikes_for_silhouette, **kwargs):
-        silhouette_scores_epochs = \
-        self.compute_metric(max_spikes_for_silhouette, **kwargs)[0]
+        silhouette_scores = \
+        self.compute_metric(max_spikes_for_silhouette, **kwargs)
         threshold_curator = ThresholdCurator(
-            sorting=self._metric_data._sorting, metrics_epoch=silhouette_scores_epochs
+            sorting=self._metric_data._sorting, metric=silhouette_scores
         )
         threshold_curator.threshold_sorting(
             threshold=threshold, threshold_sign=threshold_sign

--- a/spiketoolkit/validation/quality_metric_classes/utils/thresholdcurator.py
+++ b/spiketoolkit/validation/quality_metric_classes/utils/thresholdcurator.py
@@ -2,7 +2,7 @@ from .curationsortingextractor import CurationSortingExtractor
 
 
 class ThresholdCurator(CurationSortingExtractor):
-    def __init__(self, sorting, metrics_epoch, threshold=None, threshold_sign=None):
+    def __init__(self, sorting, metric, threshold=None, threshold_sign=None):
         '''
         Parent class for all threshold-based curators.
         
@@ -10,18 +10,18 @@ class ThresholdCurator(CurationSortingExtractor):
         ----------
         sorting: SortingExtractor
             The sorting result to be evaluated.
-        metrics_epoch: np.array
-            The metrics for the given epoch to be thresholded.
+        metrics: np.array
+            The metric to be thresholded.
         '''
         CurationSortingExtractor.__init__(self, parent_sorting=sorting)
-        self._metrics_epoch = metrics_epoch
+        self._metric = metric
         self._threshold = threshold
         self._threshold_sign = threshold_sign
 
         if threshold is not None and threshold_sign is not None:
             self.threshold_sorting(threshold, threshold_sign)
 
-        self._kwargs = {'sorting': sorting.make_serialized_dict(), 'metrics_epoch': metrics_epoch,
+        self._kwargs = {'sorting': sorting.make_serialized_dict(), 'metric': metric,
                         'threshold': threshold, 'threshold_sign': threshold_sign}
 
     def threshold_sorting(self, threshold, threshold_sign):
@@ -39,16 +39,16 @@ class ThresholdCurator(CurationSortingExtractor):
         units_to_be_excluded = []
         for i, unit_id in enumerate(self._parent_sorting.get_unit_ids()):
             if threshold_sign == 'less':
-                if self._metrics_epoch[i] < threshold:
+                if self._metric[i] < threshold:
                     units_to_be_excluded.append(unit_id)
             elif threshold_sign == 'less_or_equal':
-                if self._metrics_epoch[i] <= threshold:
+                if self._metric[i] <= threshold:
                     units_to_be_excluded.append(unit_id)
             elif threshold_sign == 'greater':
-                if self._metrics_epoch[i] > threshold:
+                if self._metric[i] > threshold:
                     units_to_be_excluded.append(unit_id)
             elif threshold_sign == 'greater_or_equal':
-                if self._metrics_epoch[i] >= threshold:
+                if self._metric[i] >= threshold:
                     units_to_be_excluded.append(unit_id)
             else:
                 raise ValueError('Not a correct threshold sign.')

--- a/spiketoolkit/validation/quality_metrics.py
+++ b/spiketoolkit/validation/quality_metrics.py
@@ -22,6 +22,7 @@ import pandas
 
 def compute_num_spikes(
         sorting,
+        duration,
         sampling_frequency=None,
         unit_ids=None,
         **kwargs
@@ -33,6 +34,8 @@ def compute_num_spikes(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated
+    duration: int
+        Length of recording (in frames).
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor
     unit_ids: list
@@ -56,7 +59,8 @@ def compute_num_spikes(
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=duration, verbose=params_dict['verbose'])
 
     ns = NumSpikes(metric_data=md)
     num_spikes = ns.compute_metric(**kwargs)
@@ -65,6 +69,7 @@ def compute_num_spikes(
 
 def compute_firing_rates(
         sorting,
+        duration,
         sampling_frequency=None,
         unit_ids=None,
         **kwargs
@@ -75,7 +80,9 @@ def compute_firing_rates(
     Parameters
     ----------
     sorting: SortingExtractor
-        The sorting result to be evaluated
+        The sorting result to be evaluated.
+    duration: int
+        Length of recording (in frames).
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor
     unit_ids: list
@@ -99,7 +106,8 @@ def compute_firing_rates(
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=duration, verbose=params_dict['verbose'])
 
     fr = FiringRate(metric_data=md)
     firing_rates = fr.compute_metric(**kwargs)
@@ -108,6 +116,7 @@ def compute_firing_rates(
 
 def compute_presence_ratios(
         sorting,
+        duration,
         sampling_frequency=None,
         unit_ids=None,
         **kwargs
@@ -119,6 +128,8 @@ def compute_presence_ratios(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
+    duration: int
+        Length of recording (in frames).
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor
     unit_ids: list
@@ -142,7 +153,8 @@ def compute_presence_ratios(
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=duration, verbose=params_dict['verbose'])
 
     pr = PresenceRatio(metric_data=md)
     presence_ratios = pr.compute_metric(**kwargs)
@@ -151,6 +163,7 @@ def compute_presence_ratios(
 
 def compute_isi_violations(
         sorting,
+        duration,
         isi_threshold=ISIViolation.params['isi_threshold'],
         min_isi=ISIViolation.params['min_isi'],
         sampling_frequency=None,
@@ -164,7 +177,9 @@ def compute_isi_violations(
     Parameters
     ----------
     sorting: SortingExtractor
-        The sorting result to be evaluated
+        The sorting result to be evaluated.
+    duration: int
+        Length of recording (in frames).
     isi_threshold: float
         The isi threshold for calculating isi violations
     min_isi: float
@@ -192,7 +207,8 @@ def compute_isi_violations(
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=duration, verbose=params_dict['verbose'])
 
     iv = ISIViolation(metric_data=md)
     isi_violations = iv.compute_metric(isi_threshold, min_isi, **kwargs)
@@ -259,7 +275,8 @@ def compute_amplitude_cutoffs(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=None, verbose=params_dict['verbose'])
 
     md.compute_amplitudes(**kwargs)
     ac = AmplitudeCutoff(metric_data=md)
@@ -358,7 +375,7 @@ def compute_snrs(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    duration=None, freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     snr = SNR(metric_data=md)
     snrs = snr.compute_metric(snr_mode, snr_noise_duration, max_spikes_per_unit_for_snr,
@@ -445,7 +462,7 @@ def compute_silhouette_scores(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    duration=None, freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -536,7 +553,8 @@ def compute_d_primes(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -627,7 +645,8 @@ def compute_l_ratios(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -719,7 +738,8 @@ def compute_isolation_distances(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -817,7 +837,8 @@ def compute_nn_metrics(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -908,7 +929,8 @@ def compute_drift_metrics(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -920,6 +942,7 @@ def compute_drift_metrics(
 def compute_quality_metrics(
         sorting,
         recording=None,
+        duration=None,
         sampling_frequency=None,
         metric_names=None,
         unit_ids=None,
@@ -949,6 +972,10 @@ def compute_quality_metrics(
         The sorting result to be evaluated.
     recording: RecordingExtractor
         The given recording extractor from which to extract amplitudes
+    duration: int
+        Length of recording (in frames).
+    sampling_frequency: float
+        The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor
     metric_names: list
         List of metric names to be computed
     unit_ids: list
@@ -1058,7 +1085,8 @@ def compute_quality_metrics(
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
+                    duration=duration, verbose=params_dict['verbose'])
 
     if "max_drift" in metric_names or "cumulative_drift" in metric_names or "silhouette_score" in metric_names \
         or "isolation_distance" in metric_names or "l_ratio" in metric_names or "d_prime" in metric_names \

--- a/spiketoolkit/validation/quality_metrics.py
+++ b/spiketoolkit/validation/quality_metrics.py
@@ -22,7 +22,6 @@ import pandas
 
 def compute_num_spikes(
         sorting,
-        duration,
         sampling_frequency=None,
         unit_ids=None,
         **kwargs
@@ -34,8 +33,6 @@ def compute_num_spikes(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated
-    duration: int
-        Length of recording (in frames).
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor
     unit_ids: list
@@ -60,7 +57,7 @@ def compute_num_spikes(
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=duration, verbose=params_dict['verbose'])
+                    duration=None, verbose=params_dict['verbose'])
 
     ns = NumSpikes(metric_data=md)
     num_spikes = ns.compute_metric(**kwargs)
@@ -1088,12 +1085,16 @@ def compute_quality_metrics(
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
                     duration=duration, verbose=params_dict['verbose'])
 
+    if "firing_rate" in metric_names or "presence_ratio" in metric_names or "isi_viol" in metric_names:
+        if recording is None and duration is None:
+            raise ValueError("Duration and recording cannot both be None when computing firing_rate, presence_ratio, and isi_viol")
+
     if "max_drift" in metric_names or "cumulative_drift" in metric_names or "silhouette_score" in metric_names \
         or "isolation_distance" in metric_names or "l_ratio" in metric_names or "d_prime" in metric_names \
             or "nn_hit_rate" in metric_names or "nn_miss_rate" in metric_names:
         if recording is None:
             raise ValueError("The recording cannot be None when computing max_drift, cumulative_drift, "
-                             "silhouette_score isolation_distance, l_ratio, d_prime, nn_hit_rate, amplitude_cutoff.")
+                             "silhouette_score isolation_distance, l_ratio, d_prime, nn_hit_rate, or amplitude_cutoff.")
         else:
             md.compute_pca_scores(**kwargs)
 

--- a/spiketoolkit/validation/quality_metrics.py
+++ b/spiketoolkit/validation/quality_metrics.py
@@ -57,7 +57,7 @@ def compute_num_spikes(
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, verbose=params_dict['verbose'])
 
     ns = NumSpikes(metric_data=md)
     num_spikes = ns.compute_metric(**kwargs)
@@ -66,7 +66,7 @@ def compute_num_spikes(
 
 def compute_firing_rates(
         sorting,
-        duration,
+        duration_in_frames,
         sampling_frequency=None,
         unit_ids=None,
         **kwargs
@@ -78,7 +78,7 @@ def compute_firing_rates(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-    duration: int
+    duration_in_frames: int
         Length of recording (in frames).
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor
@@ -104,7 +104,7 @@ def compute_firing_rates(
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=duration, verbose=params_dict['verbose'])
+                    duration_in_frames=duration_in_frames, verbose=params_dict['verbose'])
 
     fr = FiringRate(metric_data=md)
     firing_rates = fr.compute_metric(**kwargs)
@@ -113,7 +113,7 @@ def compute_firing_rates(
 
 def compute_presence_ratios(
         sorting,
-        duration,
+        duration_in_frames,
         sampling_frequency=None,
         unit_ids=None,
         **kwargs
@@ -125,7 +125,7 @@ def compute_presence_ratios(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-    duration: int
+    duration_in_frames: int
         Length of recording (in frames).
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor
@@ -151,7 +151,7 @@ def compute_presence_ratios(
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=duration, verbose=params_dict['verbose'])
+                    duration_in_frames=duration_in_frames, verbose=params_dict['verbose'])
 
     pr = PresenceRatio(metric_data=md)
     presence_ratios = pr.compute_metric(**kwargs)
@@ -160,7 +160,7 @@ def compute_presence_ratios(
 
 def compute_isi_violations(
         sorting,
-        duration,
+        duration_in_frames,
         isi_threshold=ISIViolation.params['isi_threshold'],
         min_isi=ISIViolation.params['min_isi'],
         sampling_frequency=None,
@@ -175,7 +175,7 @@ def compute_isi_violations(
     ----------
     sorting: SortingExtractor
         The sorting result to be evaluated.
-    duration: int
+    duration_in_frames: int
         Length of recording (in frames).
     isi_threshold: float
         The isi threshold for calculating isi violations
@@ -205,7 +205,7 @@ def compute_isi_violations(
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=duration, verbose=params_dict['verbose'])
+                    duration_in_frames=duration_in_frames, verbose=params_dict['verbose'])
 
     iv = ISIViolation(metric_data=md)
     isi_violations = iv.compute_metric(isi_threshold, min_isi, **kwargs)
@@ -273,7 +273,7 @@ def compute_amplitude_cutoffs(
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, verbose=params_dict['verbose'])
 
     md.compute_amplitudes(**kwargs)
     ac = AmplitudeCutoff(metric_data=md)
@@ -372,7 +372,7 @@ def compute_snrs(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    duration=None, freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     snr = SNR(metric_data=md)
     snrs = snr.compute_metric(snr_mode, snr_noise_duration, max_spikes_per_unit_for_snr,
@@ -459,7 +459,7 @@ def compute_silhouette_scores(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    duration=None, freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
+                    duration_in_frames=None, freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -551,7 +551,7 @@ def compute_d_primes(
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -643,7 +643,7 @@ def compute_l_ratios(
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -736,7 +736,7 @@ def compute_isolation_distances(
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -835,7 +835,7 @@ def compute_nn_metrics(
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -927,7 +927,7 @@ def compute_drift_metrics(
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=None, verbose=params_dict['verbose'])
+                    duration_in_frames=None, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
@@ -939,7 +939,7 @@ def compute_drift_metrics(
 def compute_quality_metrics(
         sorting,
         recording=None,
-        duration=None,
+        duration_in_frames=None,
         sampling_frequency=None,
         metric_names=None,
         unit_ids=None,
@@ -969,7 +969,7 @@ def compute_quality_metrics(
         The sorting result to be evaluated.
     recording: RecordingExtractor
         The given recording extractor from which to extract amplitudes
-    duration: int
+    duration_in_frames: int
         Length of recording (in frames).
     sampling_frequency: float
         The sampling frequency of the result. If None, will check to see if sampling frequency is in sorting extractor
@@ -1083,11 +1083,11 @@ def compute_quality_metrics(
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
                     freq_max=params_dict["freq_max"], unit_ids=unit_ids, 
-                    duration=duration, verbose=params_dict['verbose'])
+                    duration_in_frames=duration_in_frames, verbose=params_dict['verbose'])
 
     if "firing_rate" in metric_names or "presence_ratio" in metric_names or "isi_viol" in metric_names:
-        if recording is None and duration is None:
-            raise ValueError("Duration and recording cannot both be None when computing firing_rate, presence_ratio, and isi_viol")
+        if recording is None and duration_in_frames is None:
+            raise ValueError("duration_in_frames and recording cannot both be None when computing firing_rate, presence_ratio, and isi_viol")
 
     if "max_drift" in metric_names or "cumulative_drift" in metric_names or "silhouette_score" in metric_names \
         or "isolation_distance" in metric_names or "l_ratio" in metric_names or "d_prime" in metric_names \

--- a/spiketoolkit/validation/quality_metrics.py
+++ b/spiketoolkit/validation/quality_metrics.py
@@ -14,6 +14,7 @@ from .quality_metric_classes.drift_metric import DriftMetric
 from .quality_metric_classes.parameter_dictionaries import update_all_param_dicts_with_kwargs
 from collections import OrderedDict
 from copy import deepcopy
+import pandas
 
 
 # All parameter values are stored in the class definitions
@@ -38,10 +39,6 @@ def compute_num_spikes(
         List of unit ids to compute metric for. If not specified, all units are used
     **kwargs: keyword arguments
         Keyword arguments among the following:
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
             save_property_or_features: bool
                 If True, the metric is saved as sorting property
             verbose: bool
@@ -49,8 +46,8 @@ def compute_num_spikes(
 
     Returns
     ----------
-    num_spikes_epochs: list of lists
-        The num spikes of the sorted units in the given epochs
+    num_spikes: np.ndarray
+        The number of spikes of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -59,12 +56,11 @@ def compute_num_spikes(
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     ns = NumSpikes(metric_data=md)
-    num_spikes_epochs = ns.compute_metric(**kwargs)
-    return num_spikes_epochs
+    num_spikes = ns.compute_metric(**kwargs)
+    return num_spikes
 
 
 def compute_firing_rates(
@@ -86,10 +82,6 @@ def compute_firing_rates(
         List of unit ids to compute metric for. If not specified, all units are used
     **kwargs: keyword arguments
         Keyword arguments among the following:
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
             save_property_or_features: bool
                 If True, the metric is saved as sorting property
             verbose: bool
@@ -97,8 +89,8 @@ def compute_firing_rates(
 
     Returns
     ----------
-    firing_rate_epochs: list of lists
-        The firing rates of the sorted units in the given epochs
+    firing_rates: np.ndarray
+        The firing rates of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -107,12 +99,11 @@ def compute_firing_rates(
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     fr = FiringRate(metric_data=md)
-    firing_rate_epochs = fr.compute_metric(**kwargs)
-    return firing_rate_epochs
+    firing_rates = fr.compute_metric(**kwargs)
+    return firing_rates
 
 
 def compute_presence_ratios(
@@ -134,10 +125,6 @@ def compute_presence_ratios(
         List of unit ids to compute metric for. If not specified, all units are used
     **kwargs: keyword arguments
         Keyword arguments among the following:
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
             save_property_or_features: bool
                 If True, the metric is saved as sorting property
             verbose: bool
@@ -145,8 +132,8 @@ def compute_presence_ratios(
 
     Returns
     ----------
-    presence_ratio_epochs: list of lists
-        The presence ratios of the sorted units in the given epochs
+    presence_ratios: np.ndarray
+        The presence ratios of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -155,12 +142,11 @@ def compute_presence_ratios(
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     pr = PresenceRatio(metric_data=md)
-    presence_ratio_epochs = pr.compute_metric(**kwargs)
-    return presence_ratio_epochs
+    presence_ratios = pr.compute_metric(**kwargs)
+    return presence_ratios
 
 
 def compute_isi_violations(
@@ -189,10 +175,6 @@ def compute_isi_violations(
         List of unit ids to compute metric for. If not specified, all units are used
     **kwargs: keyword arguments
         Keyword arguments among the following:
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
             save_property_or_features: bool
                 If True, the metric is saved as sorting property
             verbose: bool
@@ -200,8 +182,8 @@ def compute_isi_violations(
 
     Returns
     ----------
-    isi_violation_epochs: list of lists
-        The isi violations of the sorted units in the given epochs
+    isi_violations: np.ndarray
+        The isi violations of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -210,12 +192,11 @@ def compute_isi_violations(
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=None,
                     apply_filter=False, freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     iv = ISIViolation(metric_data=md)
-    isi_violation_epochs = iv.compute_metric(isi_threshold, min_isi, **kwargs)
-    return isi_violation_epochs
+    isi_violations = iv.compute_metric(isi_threshold, min_isi, **kwargs)
+    return isi_violations
 
 
 def compute_amplitude_cutoffs(
@@ -265,15 +246,11 @@ def compute_amplitude_cutoffs(
                 Random seed for reproducibility
             verbose: bool
                 If True, will be verbose in metric computation
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
 
     Returns
     ----------
-    amplitude_cutoffs_epochs: list of lists
-        The amplitude cutoffs of the sorted units in the given epochs
+    amplitude_cutoffs: np.ndarray
+        The amplitude cutoffs of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -282,13 +259,12 @@ def compute_amplitude_cutoffs(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     md.compute_amplitudes(**kwargs)
     ac = AmplitudeCutoff(metric_data=md)
-    amplitude_cutoffs_epochs = ac.compute_metric(**kwargs)
-    return amplitude_cutoffs_epochs
+    amplitude_cutoffs = ac.compute_metric(**kwargs)
+    return amplitude_cutoffs
 
 
 def compute_snrs(
@@ -369,15 +345,11 @@ def compute_snrs(
                 Random seed for reproducibility
             verbose: bool
                 If True, will be verbose in metric computation
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
 
     Returns
     ----------
-    snr_epochs: list of lists
-        The snrs of the sorted units in the given epochs
+    snrs: np.ndarray
+        The snrs of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -386,13 +358,12 @@ def compute_snrs(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     snr = SNR(metric_data=md)
-    snr_epochs = snr.compute_metric(snr_mode, snr_noise_duration, max_spikes_per_unit_for_snr,
+    snrs = snr.compute_metric(snr_mode, snr_noise_duration, max_spikes_per_unit_for_snr,
                                     template_mode, max_channel_peak, **kwargs)
-    return snr_epochs
+    return snrs
 
 
 def compute_silhouette_scores(
@@ -461,15 +432,11 @@ def compute_silhouette_scores(
                 Random seed for reproducibility
             verbose: bool
                 If True, will be verbose in metric computation
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
 
     Returns
     ----------
-    silhouette_score_epochs: list of lists
-        The sihouette scores of the sorted units in the given epochs
+    silhouette_scores: np.ndarray
+        The sihouette scores of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -478,14 +445,13 @@ def compute_silhouette_scores(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
     silhouette_score = SilhouetteScore(metric_data=md)
-    silhouette_score_epochs = silhouette_score.compute_metric(max_spikes_for_silhouette, **kwargs)
-    return silhouette_score_epochs
+    silhouette_scores = silhouette_score.compute_metric(max_spikes_for_silhouette, **kwargs)
+    return silhouette_scores
 
 
 def compute_d_primes(
@@ -557,15 +523,11 @@ def compute_d_primes(
                 Random seed for reproducibility
             verbose: bool
                 If True, will be verbose in metric computation
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
 
     Returns
     ----------
-    d_prime_epochs: list of lists
-        The d primes of the sorted units in the given epochs
+    d_primes: np.ndarray
+        The d primes of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -574,14 +536,13 @@ def compute_d_primes(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
     d_prime = DPrime(metric_data=md)
-    d_prime_epochs = d_prime.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
-    return d_prime_epochs
+    d_primes = d_prime.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
+    return d_primes
 
 
 def compute_l_ratios(
@@ -653,15 +614,11 @@ def compute_l_ratios(
                 Random seed for reproducibility
             verbose: bool
                 If True, will be verbose in metric computation
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
 
     Returns
     ----------
-    l_ratio_epochs: list of lists
-        The l ratios of the sorted units in the given epochs
+    l_ratios: np.ndarray
+        The l ratios of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -670,14 +627,13 @@ def compute_l_ratios(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
     l_ratio = LRatio(metric_data=md)
-    l_ratio_epochs = l_ratio.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
-    return l_ratio_epochs
+    l_ratios = l_ratio.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
+    return l_ratios
 
 
 def compute_isolation_distances(
@@ -750,15 +706,11 @@ def compute_isolation_distances(
                 Random seed for reproducibility
             verbose: bool
                 If True, will be verbose in metric computation
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
 
     Returns
     ----------
-    isolation_distance_epochs: list of lists
-        The isolation distances of the sorted units in the given epochs
+    isolation_distances: np.ndarray
+        The isolation distances of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -767,15 +719,14 @@ def compute_isolation_distances(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
     isolation_distance = IsolationDistance(metric_data=md)
-    isolation_distance_epochs = isolation_distance.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
-                                                                  **kwargs)
-    return isolation_distance_epochs
+    isolation_distances = isolation_distance.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
+                                                            **kwargs)
+    return isolation_distances
 
 
 def compute_nn_metrics(
@@ -853,15 +804,11 @@ def compute_nn_metrics(
                 Random seed for reproducibility
             verbose: bool
                 If True, will be verbose in metric computation
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
 
     Returns
     ----------
-    nn_metrics_epochs: list of lists
-        The nearest neighbor metrics of the sorted units in the given epochs
+    nn_metrics: np.ndarray
+        The nearest neighbor metrics of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -870,15 +817,14 @@ def compute_nn_metrics(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
     nn = NearestNeighbor(metric_data=md)
-    nn_metrics_epochs = nn.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
-                                          max_spikes_for_nn, n_neighbors, **kwargs)
-    return nn_metrics_epochs
+    nn_metrics = nn.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
+                                   max_spikes_for_nn, n_neighbors, **kwargs)
+    return nn_metrics
 
 
 def compute_drift_metrics(
@@ -950,15 +896,10 @@ def compute_drift_metrics(
                 Random seed for reproducibility
             verbose: bool
                 If True, will be verbose in metric computation
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
-
     Returns
     ----------
-    dm_metrics_epochs: list of lists
-        The drift metrics of the sorted units in the given epochs
+    dm_metrics: np.ndarray
+        The drift metrics of the sorted units.
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
@@ -967,23 +908,22 @@ def compute_drift_metrics(
 
     md = MetricData(sorting=sorting, sampling_frequency=recording.get_sampling_frequency(), recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     md.compute_pca_scores(**kwargs)
 
     dm = DriftMetric(metric_data=md)
-    dm_metrics_epochs = dm.compute_metric(drift_metrics_interval_s, drift_metrics_min_spikes_per_interval, **kwargs)
-    return dm_metrics_epochs
+    dm_metrics = dm.compute_metric(drift_metrics_interval_s, drift_metrics_min_spikes_per_interval, **kwargs)
+    return dm_metrics
 
 
-def compute_metrics(
+def compute_quality_metrics(
         sorting,
         recording=None,
         sampling_frequency=None,
         metric_names=None,
         unit_ids=None,
-        return_dict=False,
+        as_dataframe=False,
         isi_threshold=ISIViolation.params['isi_threshold'],
         min_isi=ISIViolation.params['min_isi'],
         snr_mode=SNR.params['snr_mode'],
@@ -1013,8 +953,8 @@ def compute_metrics(
         List of metric names to be computed
     unit_ids: list
         List of unit ids to compute metric for. If not specified, all units are used
-    return_dict: bool
-        If True, will return dict of metrics
+    as_dataframe: bool
+        If True, will return dataframe of metrics. If False, will return dictionary.
     isi_threshold: float
         The isi threshold for calculating isi violations
     min_isi: float
@@ -1089,23 +1029,15 @@ def compute_metrics(
                 Random seed for reproducibility
             verbose: bool
                 If True, will be verbose in metric computation
-            epoch_tuples: list
-                A list of tuples with a start and end time for each epoch
-            epoch_names: list
-                A list of strings for the names of the given epochs
 
     Returns
     ----------
-    metrics_epochs : list of lists
-        List of metrics data. The list consists of lists of metric data for each given epoch
-    OR
-    metrics_dict: OrderedDict
-        Dict of metrics data. The dict consists of lists of metric data for each given epoch for each metric
+    metrics: dictionary OR pandas.dataframe
+        Dictionary or pandas.dataframe of metrics.
     
     """
     params_dict = update_all_param_dicts_with_kwargs(kwargs)
 
-    metrics_epochs = []
     metrics_dict = OrderedDict()
     all_metrics_list = ["num_spikes", "firing_rate", "presence_ratio", "isi_viol", "amplitude_cutoff", "snr",
                         "max_drift", "cumulative_drift", "silhouette_score", "isolation_distance", "l_ratio",
@@ -1126,8 +1058,7 @@ def compute_metrics(
 
     md = MetricData(sorting=sorting, sampling_frequency=sampling_frequency, recording=recording,
                     apply_filter=params_dict["apply_filter"], freq_min=params_dict["freq_min"],
-                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, epoch_tuples=params_dict["epoch_tuples"],
-                    epoch_names=params_dict["epoch_names"], verbose=params_dict['verbose'])
+                    freq_max=params_dict["freq_max"], unit_ids=unit_ids, verbose=params_dict['verbose'])
 
     if "max_drift" in metric_names or "cumulative_drift" in metric_names or "silhouette_score" in metric_names \
         or "isolation_distance" in metric_names or "l_ratio" in metric_names or "d_prime" in metric_names \
@@ -1149,98 +1080,76 @@ def compute_metrics(
 
     if "num_spikes" in metric_names:
         ns = NumSpikes(metric_data=md)
-        num_spikes_epochs = ns.compute_metric(**kwargs)
-        metrics_epochs.append(num_spikes_epochs)
-        metrics_dict['num_spikes'] = num_spikes_epochs
+        num_spikes = ns.compute_metric(**kwargs)
+        metrics_dict['num_spikes'] = num_spikes
 
     if "firing_rate" in metric_names:
         fr = FiringRate(metric_data=md)
-        firing_rate_epochs = fr.compute_metric(**kwargs)
-        metrics_epochs.append(firing_rate_epochs)
-        metrics_dict['firing_rate'] = firing_rate_epochs
+        firing_rates = fr.compute_metric(**kwargs)
+        metrics_dict['firing_rate'] = firing_rates
 
     if "presence_ratio" in metric_names:
         pr = PresenceRatio(metric_data=md)
-        presence_ratio_epochs = pr.compute_metric(**kwargs)
-        metrics_epochs.append(presence_ratio_epochs)
-        metrics_dict['presence_ratio'] = presence_ratio_epochs
+        presence_ratios = pr.compute_metric(**kwargs)
+        metrics_dict['presence_ratio'] = presence_ratios
 
     if "isi_viol" in metric_names:
         iv = ISIViolation(metric_data=md)
-        isi_violation_epochs = iv.compute_metric(isi_threshold, min_isi, **kwargs)
-        metrics_epochs.append(isi_violation_epochs)
-        metrics_dict['isi_viol'] = isi_violation_epochs
+        isi_violations = iv.compute_metric(isi_threshold, min_isi, **kwargs)
+        metrics_dict['isi_viol'] = isi_violations
 
     if "amplitude_cutoff" in metric_names:
         ac = AmplitudeCutoff(metric_data=md)
-        amplitude_cutoffs_epochs = ac.compute_metric(**kwargs)
-        metrics_epochs.append(amplitude_cutoffs_epochs)
-        metrics_dict['amplitude_cutoff'] = amplitude_cutoffs_epochs
+        amplitude_cutoffs = ac.compute_metric(**kwargs)
+        metrics_dict['amplitude_cutoff'] = amplitude_cutoffs
 
     if "snr" in metric_names:
         snr = SNR(metric_data=md)
-        snr_epochs = snr.compute_metric(snr_mode, snr_noise_duration, max_spikes_per_unit_for_snr,
+        snrs = snr.compute_metric(snr_mode, snr_noise_duration, max_spikes_per_unit_for_snr,
                                         template_mode, max_channel_peak, **kwargs)
-        metrics_epochs.append(snr_epochs)
-        metrics_dict['snr'] = snr_epochs
+        metrics_dict['snr'] = snrs
 
     if "max_drift" in metric_names or "cumulative_drift" in metric_names:
         dm = DriftMetric(metric_data=md)
-        dm_metrics_epochs = dm.compute_metric(drift_metrics_interval_s, drift_metrics_min_spikes_per_interval, **kwargs)
-        max_drifts_epochs = []
-        cumulative_drifts_epochs = []
-        for dm_metric in dm_metrics_epochs:
-            max_drifts_epochs.append(dm_metric[0])
-            cumulative_drifts_epochs.append(dm_metric[1])
+        max_drifts, cumulative_drifts = dm.compute_metric(drift_metrics_interval_s, drift_metrics_min_spikes_per_interval, **kwargs)
         if "max_drift" in metric_names:
-            metrics_epochs.append(max_drifts_epochs)
-            metrics_dict['max_drift'] = max_drifts_epochs
+            metrics_dict['max_drift'] = max_drifts
         if "cumulative_drift" in metric_names:
-            metrics_epochs.append(cumulative_drifts_epochs)
-            metrics_dict['cumulative_drift'] = cumulative_drifts_epochs
+            metrics_dict['cumulative_drift'] = cumulative_drifts
 
     if "silhouette_score" in metric_names:
         silhouette_score = SilhouetteScore(metric_data=md)
-        silhouette_score_epochs = silhouette_score.compute_metric(max_spikes_for_silhouette, **kwargs)
-        metrics_epochs.append(silhouette_score_epochs)
-        metrics_dict['silhouette_score'] = silhouette_score_epochs
+        silhouette_scores = silhouette_score.compute_metric(max_spikes_for_silhouette, **kwargs)
+        metrics_dict['silhouette_score'] = silhouette_scores
 
     if "isolation_distance" in metric_names:
         isolation_distance = IsolationDistance(metric_data=md)
-        isolation_distance_epochs = isolation_distance.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
-                                                                      **kwargs)
-        metrics_epochs.append(isolation_distance_epochs)
-        metrics_dict['isolation_distance'] = isolation_distance_epochs
+        isolation_distances = isolation_distance.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
+                                                                **kwargs)
+        metrics_dict['isolation_distance'] = isolation_distances
 
     if "l_ratio" in metric_names:
         l_ratio = LRatio(metric_data=md)
-        l_ratio_epochs = l_ratio.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
-        metrics_epochs.append(l_ratio_epochs)
-        metrics_dict['l_ratio'] = l_ratio_epochs
+        l_ratios = l_ratio.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
+        metrics_dict['l_ratio'] = l_ratios
 
     if "d_prime" in metric_names:
         d_prime = DPrime(metric_data=md)
-        d_prime_epochs = d_prime.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
-        metrics_epochs.append(d_prime_epochs)
-        metrics_dict['d_prime'] = d_prime_epochs
+        d_primes = d_prime.compute_metric(num_channels_to_compare, max_spikes_per_cluster, **kwargs)
+        metrics_dict['d_prime'] = d_primes
 
     if "nn_hit_rate" in metric_names or "nn_miss_rate" in metric_names:
         nn = NearestNeighbor(metric_data=md)
-        nn_metrics_epochs = nn.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
-                                              max_spikes_for_nn, n_neighbors, **kwargs)
-        nn_hit_rates_epochs = []
-        nn_miss_rates_epochs = []
-        for nn_metric in nn_metrics_epochs:
-            nn_hit_rates_epochs.append(nn_metric[0])
-            nn_miss_rates_epochs.append(nn_metric[1])
+        nn_hit_rates, nn_miss_rates= nn.compute_metric(num_channels_to_compare, max_spikes_per_cluster,
+                                                       max_spikes_for_nn, n_neighbors, **kwargs)
         if "nn_hit_rate" in metric_names:
-            metrics_epochs.append(nn_hit_rates_epochs)
-            metrics_dict['nn_hit_rate'] = nn_hit_rates_epochs
+            metrics_dict['nn_hit_rate'] = nn_hit_rates
         if "nn_miss_rate" in metric_names:
-            metrics_epochs.append(nn_miss_rates_epochs)
-            metrics_dict['nn_miss_rate'] = nn_miss_rates_epochs
+            metrics_dict['nn_miss_rate'] = nn_miss_rates
 
-    if return_dict:
-        return metrics_dict
+    if as_dataframe:
+        metrics = pandas.DataFrame.from_dict(metrics_dict)
+        metrics = metrics.rename(index={original_idx:unit_ids[i] for i, original_idx in enumerate(range(len(metrics)))})
     else:
-        return metrics_epochs
+        metrics = metrics_dict
+    return metrics

--- a/spiketoolkit/validation/validation_list.py
+++ b/spiketoolkit/validation/validation_list.py
@@ -11,7 +11,7 @@ from .quality_metrics import (
     compute_l_ratios,
     compute_d_primes,
     compute_nn_metrics,
-    compute_metrics,
+    compute_quality_metrics,
 )
 
 from .quality_metric_classes.utils.validation_tools import get_pca_metric_data, \


### PR DESCRIPTION
WIP on removing epochs from quality metrics --> replacing them with manual subsorting and subrecording extractors.

@alejoe91 I ran into a little issue with the `waveforms_idxs`  spike feature... for some reason it is stored as a list instead of a numpy array so when you call get_epoch on a sorting extractor with this feature, it will throw an error. I can't find where this feature is set. Could you point me to the relevant code?
