### PR TITLE
Override `get_dtype` in FilterRecordingExtractor and ResampleRecordingExtractor

### DIFF
--- a/spiketoolkit/preprocessing/filterrecording.py
+++ b/spiketoolkit/preprocessing/filterrecording.py
@@ -31,6 +31,9 @@ class FilterRecording(RecordingExtractor):
             offset = - 2**(exp - 1) - 1
             self._recording = TransformRecording(self._recording, offset=offset, dtype=dtype_signed)
             print(f"dtype converted from {dtype} to {dtype_signed} before filtering")
+            self._dtype = dtype_signed
+        else:
+            self._dtype = dtype
         self.copy_channel_properties(recording)
 
     def get_channel_ids(self):
@@ -41,6 +44,10 @@ class FilterRecording(RecordingExtractor):
 
     def get_sampling_frequency(self):
         return self._recording.get_sampling_frequency()
+
+    # avoid filtering one sample
+    def get_dtype(self):
+        return self._dtype
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
@@ -65,7 +72,7 @@ class FilterRecording(RecordingExtractor):
                 pos += (end0-start0)
         else:
             filtered_chunk = self.filter_chunk(start_frame=start_frame, end_frame=end_frame)[channel_ids, :]
-        return filtered_chunk
+        return filtered_chunk.astype(self._dtype)
 
     @abstractmethod
     def filter_chunk(self, *, start_frame, end_frame):

--- a/spiketoolkit/preprocessing/resample.py
+++ b/spiketoolkit/preprocessing/resample.py
@@ -20,6 +20,7 @@ class ResampleRecording(RecordingExtractor):
         self._recording = recording
         self._resample_rate = resample_rate
         RecordingExtractor.__init__(self)
+        self._dtype = recording.get_dtype()
         self.copy_channel_properties(recording)
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'resample_rate': resample_rate}
@@ -29,6 +30,10 @@ class ResampleRecording(RecordingExtractor):
 
     def get_num_frames(self):
         return int(self._recording.get_num_frames() / self._recording.get_sampling_frequency() * self._resample_rate)
+
+    # avoid filtering one sample
+    def get_dtype(self):
+        return self._dtype
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
@@ -47,7 +52,7 @@ class ResampleRecording(RecordingExtractor):
                                                axis=1)
         else:
             traces_resampled = signal.resample(traces, int(end_frame_sampled - start_frame_sampled), axis=1)
-        return traces_resampled
+        return traces_resampled.astype(self._dtype)
 
     def get_channel_ids(self):
         return self._recording.get_channel_ids()


### PR DESCRIPTION
the `get_dtype` in the base recording extractor attempts to extract one frame with get traces. This fails with some filters. Better to store the dtype and cast the returned traces