### PR TITLE
Re-add spikefeatures in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'spikeextractors',
         'spikesorters',
         'spikemetrics >= 0.2.0',
+        'spikefeatures',
         'scikit-learn',
         'scipy',
         'pandas',


### PR DESCRIPTION
@colehurwitz remember to merge to master before merging a PR

`spikefeatures` was removed in the setup.py
https://github.com/SpikeInterface/spiketoolkit/blob/7a16b0e4e5b3d67dde66b9ef43ad94312091c2f1/setup.py#L26