### PR TITLE
return unit ids curation sorting extractor

### DIFF
--- a/spiketoolkit/tests/test_curation_extractor.py
+++ b/spiketoolkit/tests/test_curation_extractor.py
@@ -74,7 +74,8 @@ class TestCuration(unittest.TestCase):
         CSX = st.validation.quality_metric_classes.utils.curationsortingextractor.CurationSortingExtractor(
             parent_sorting=self.SX
         )
-        CSX.merge_units(unit_ids=[1, 2])
+        merged_unit_id = CSX.merge_units(unit_ids=[1, 2])
+        self.assertEqual(merged_unit_id, 4)
         original_spike_train = np.concatenate((self.SX.get_unit_spike_train(1), self.SX.get_unit_spike_train(2)))
         indices_sort = np.argsort(original_spike_train)
         original_spike_train = original_spike_train[indices_sort]
@@ -85,7 +86,9 @@ class TestCuration(unittest.TestCase):
         self.assertTrue(np.array_equal(np.asarray(CSX.get_unit_spike_feature_names(4)), np.asarray(['f_int'])))
         self.assertEqual(CSX.get_sampling_frequency(), self.SX.get_sampling_frequency())
 
-        CSX.split_unit(unit_id=3, indices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        unit_ids_split = CSX.split_unit(unit_id=3, indices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertEqual(unit_ids_split[0], 5)
+        self.assertEqual(unit_ids_split[1], 6)
         original_spike_train = self.SX.get_unit_spike_train(3)
         original_features = self.SX.get_unit_spike_features(3, 'f_int')
         split_spike_train_1 = CSX.get_unit_spike_train(5)

--- a/spiketoolkit/validation/quality_metric_classes/utils/curationsortingextractor.py
+++ b/spiketoolkit/validation/quality_metric_classes/utils/curationsortingextractor.py
@@ -106,10 +106,15 @@ class CurationSortingExtractor(SortingExtractor):
         ----------
         unit_ids: list
             The unit ids to be merged
+
+        Returns
+        -------
+        new_root_id: int
+            The unit id of the new merged unit.
         '''
         
         if len(unit_ids) <= 1:
-            return
+            return None
 
         root_ids = []
         for i in range(len(self._roots)):
@@ -184,7 +189,7 @@ class CurationSortingExtractor(SortingExtractor):
                                                  indexes=shared_features_idxs_sorted)
             del spike_train
             del all_spike_trains
-            
+            return new_root_id
         else:
             raise ValueError(str(unit_ids) + " has one or more invalid unit ids")
 
@@ -198,6 +203,11 @@ class CurationSortingExtractor(SortingExtractor):
             The unit id to be split
         indices: list
             The indices of the unit spike train at which the spike train will be split.
+
+        Returns
+        -------
+        new_root_ids: tuple
+            A tuple of new unit ids after the split (integers).
         '''
         root_ids = []
         for i in range(len(self._roots)):
@@ -241,6 +251,7 @@ class CurationSortingExtractor(SortingExtractor):
                 self.set_unit_spike_features(new_root_2_id, feature_name, full_features[indices_2])
             del self._features[unit_id]
             del self._roots[root_index]
+            return (new_root_1_id, new_root_2_id)
         else:
             raise ValueError(str(unit_id) + " non-valid unit id")
 


### PR DESCRIPTION
#355 

Split and merge in the `CurationSortingExtractor` now return the new unit_ids as requested.