### PR TITLE
Update postprocessing_tools.py

### DIFF
--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1141,7 +1141,7 @@ def export_to_phy(recording, sorting, output_folder, compute_pc_features=True,
     if copy_binary:
         rec_path = 'recording.dat'  # Use relative path in this case
         recording.write_to_binary_dat_format(output_folder / rec_path, dtype=dtype)      
-    elif isinstance(recording, se.CacheRecordingExtractor) or isinstance(recording, se.BinDatRecordingExtractor): # Don't save recording.dat, use path to the raw file instead
+    elif isinstance(recording, (se.CacheRecordingExtractor, se.BinDatRecordingExtractor)): # don't save recording.dat, use path to the raw file instead
         rec_path = str(Path(recording.filename).absolute())
         dtype = recording.get_dtype()
     else: # Don't save recording.dat

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1053,8 +1053,10 @@ def export_to_phy(recording, sorting, output_folder, compute_pc_features=True,
     max_channels_per_template: int or None
         Maximum channels per unit to return. If None, all channels are returned
     copy_binary: bool
-        Copy or not binary file in phy/ directory. If False and recording object
-        is Cache or BinDat extractors link the original raw file. Default is True.
+        If True, the recording is copied and saved in the phy 'output_folder'. If False and the 
+        'recording' is a CacheRecordingExtractor or a BinDatRecordingExtractor, then a relative
+        link to the file recording location is used. Otherwise, the recording is not copied and the
+        recording path is set to 'None'. (default True)
     **kwargs: Keyword arguments
         A dictionary with default values can be retrieved with:
         st.postprocessing.get_waveforms_params():

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1144,7 +1144,7 @@ def export_to_phy(recording, sorting, output_folder, compute_pc_features=True,
     elif isinstance(recording, (se.CacheRecordingExtractor, se.BinDatRecordingExtractor)): # don't save recording.dat, use path to the raw file instead
         rec_path = str(Path(recording.filename).absolute())
         dtype = recording.get_dtype()
-    else: # Don't save recording.dat
+    else: # don't save recording.dat
         rec_path = 'None' 
 
     # write params.py


### PR DESCRIPTION
Add copy_binary params to export_to_phy, 
If False:  don't copy recording.dat
   If recording is BindatRecordingExtractor or CacheRecordingExtractor: absolute link to the file location
   else: link to recording object is 'None'
If True: copy recording.dat and use relative link

To test:

```
import pytest
import spikeextractors as se
from spiketoolkit.postprocessing import export_to_phy
import os
import shutil

@pytest.mark.implemented
def test_export_to_phy():
    folder = 'test'
    if os.path.isdir(folder):
        shutil.rmtree(folder)
    rec, sort = se.example_datasets.toy_example(dump_folder=folder, dumpable=True, duration=10, num_channels=8)

    rec_Cache = se.CacheRecordingExtractor(rec)
    
    export_to_phy(rec, sort, output_folder='phy')#, copy_binary=True)
    export_to_phy(rec, sort, output_folder='phy_without_recording', copy_binary=False)
    export_to_phy(rec_Cache, sort, output_folder='phy_without_recording_cache', copy_binary=False)

    


if __name__ == '__main__':
    test_export_to_phy()
```