### PR TITLE
fix disappearing epochs in preprocessors

### DIFF
--- a/spiketoolkit/preprocessing/bandpass_filter.py
+++ b/spiketoolkit/preprocessing/bandpass_filter.py
@@ -31,7 +31,6 @@ class BandpassFilterRecording(FilterRecording):
                 raise ValueError('Filter is not stable')
         FilterRecording.__init__(self, recording=recording, chunk_size=chunk_size, cache_chunks=cache_chunks,
                                  dtype=dtype)
-        self.copy_channel_properties(recording)
 
         self.is_filtered = True
         self._kwargs = {'recording': recording.make_serialized_dict(), 'freq_min': freq_min, 'freq_max': freq_max,

--- a/spiketoolkit/preprocessing/blank_saturation.py
+++ b/spiketoolkit/preprocessing/blank_saturation.py
@@ -32,6 +32,7 @@ class BlankSaturationRecording(RecordingExtractor):
                 self._lower = True
         RecordingExtractor.__init__(self)
         self.copy_channel_properties(recording=self._recording)
+        self.copy_epochs(recording)
         self.is_filtered = self._recording.is_filtered
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'threshold': threshold, 'seed': seed}

--- a/spiketoolkit/preprocessing/center.py
+++ b/spiketoolkit/preprocessing/center.py
@@ -46,7 +46,6 @@ class CenterRecording(TransformRecording):
             dtype = dtype[1:]
         TransformRecording.__init__(self, self._recording, scalar=self._scalar, offset=self._offset, dtype=dtype)
         self.is_filtered = self._recording.is_filtered
-        self.copy_channel_properties(recording=self._recording)
         self._kwargs = {'recording': recording.make_serialized_dict(), 'mode': mode, 'seconds': seconds,
                         'n_snippets': n_snippets}
 

--- a/spiketoolkit/preprocessing/clip.py
+++ b/spiketoolkit/preprocessing/clip.py
@@ -15,7 +15,8 @@ class ClipRecording(RecordingExtractor):
         self._a_min = a_min
         self._a_max = a_max
         RecordingExtractor.__init__(self)
-        self.copy_channel_properties(recording=self._recording)
+        self.copy_channel_properties(recording=recording)
+        self.copy_epochs(recording)
         self.is_filtered = self._recording.is_filtered
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'a_min': a_min, 'a_max': a_max}

--- a/spiketoolkit/preprocessing/common_reference.py
+++ b/spiketoolkit/preprocessing/common_reference.py
@@ -35,7 +35,8 @@ class CommonReferenceRecording(RecordingExtractor):
             self._dtype = dtype
         self.verbose = verbose
         RecordingExtractor.__init__(self)
-        self.copy_channel_properties(recording=self._recording)
+        self.copy_channel_properties(recording=recording)
+        self.copy_epochs(recording)
         self.is_filtered = self._recording.is_filtered
 
         # update dump dict

--- a/spiketoolkit/preprocessing/filterrecording.py
+++ b/spiketoolkit/preprocessing/filterrecording.py
@@ -36,6 +36,7 @@ class FilterRecording(RecordingExtractor):
         else:
             self._dtype = dtype
         self.copy_channel_properties(recording)
+        self.copy_epochs(recording)
 
     def get_channel_ids(self):
         return self._recording.get_channel_ids()

--- a/spiketoolkit/preprocessing/normalize_by_quantile.py
+++ b/spiketoolkit/preprocessing/normalize_by_quantile.py
@@ -20,7 +20,8 @@ class NormalizeByQuantileRecording(RecordingExtractor):
         self._scalar = scale / pre_scale
         self._offset = median - pre_median * self._scalar
         RecordingExtractor.__init__(self)
-        self.copy_channel_properties(recording=self._recording)
+        self.copy_channel_properties(recording=recording)
+        self.copy_epochs(recording)
         self.is_filtered = self._recording.is_filtered
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'scale': scale, 'median': median,

--- a/spiketoolkit/preprocessing/notch_filter.py
+++ b/spiketoolkit/preprocessing/notch_filter.py
@@ -19,7 +19,6 @@ class NotchFilterRecording(FilterRecording):
         if not np.all(np.abs(np.roots(self._a)) < 1):
             raise ValueError('Filter is not stable')
         FilterRecording.__init__(self, recording=recording, chunk_size=chunk_size, cache_chunks=cache_chunks)
-        self.copy_channel_properties(recording)
         self.is_filtered = self._recording.is_filtered
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'freq': freq,

--- a/spiketoolkit/preprocessing/rectify.py
+++ b/spiketoolkit/preprocessing/rectify.py
@@ -13,6 +13,7 @@ class RectifyRecording(RecordingExtractor):
         self._recording = recording
         RecordingExtractor.__init__(self)
         self.copy_channel_properties(recording)
+        self.copy_epochs(recording)
         self.is_filtered = self._recording.is_filtered
 
         self._kwargs = {'recording': recording.make_serialized_dict()}

--- a/spiketoolkit/preprocessing/remove_artifacts.py
+++ b/spiketoolkit/preprocessing/remove_artifacts.py
@@ -17,6 +17,7 @@ class RemoveArtifactsRecording(RecordingExtractor):
         self._ms_after = ms_after
         RecordingExtractor.__init__(self)
         self.copy_channel_properties(recording=self._recording)
+        self.copy_epochs(recording)
         self.is_filtered = self._recording.is_filtered
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'triggers': triggers,

--- a/spiketoolkit/preprocessing/remove_bad_channels.py
+++ b/spiketoolkit/preprocessing/remove_bad_channels.py
@@ -19,6 +19,7 @@ class RemoveBadChannelsRecording(RecordingExtractor):
         self._initialize_subrecording_extractor()
         RecordingExtractor.__init__(self)
         self.copy_channel_properties(recording=self._subrecording)
+        self.copy_epochs(recording)
         self.is_filtered = self._recording.is_filtered
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'bad_channel_ids': bad_channel_ids,

--- a/spiketoolkit/preprocessing/resample.py
+++ b/spiketoolkit/preprocessing/resample.py
@@ -22,6 +22,7 @@ class ResampleRecording(RecordingExtractor):
         RecordingExtractor.__init__(self)
         self._dtype = recording.get_dtype()
         self.copy_channel_properties(recording)
+        self.copy_epochs(recording)
         self.is_filtered = self._recording.is_filtered
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'resample_rate': resample_rate}

--- a/spiketoolkit/preprocessing/transform.py
+++ b/spiketoolkit/preprocessing/transform.py
@@ -20,7 +20,8 @@ class TransformRecording(RecordingExtractor):
             self._dtype = dtype
         RecordingExtractor.__init__(self)
         self._recording = recording
-        self.copy_channel_properties(recording=self._recording)
+        self.copy_channel_properties(recording=recording)
+        self.copy_epochs(recording)
         self.is_filtered = self._recording.is_filtered
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'scalar': scalar, 'offset': offset,


### PR DESCRIPTION
Fixes #406 by correctly copying over epoch information after preprocessing.