### PR TITLE
Compute COM and refractor spiking activity

### DIFF
--- a/spiketoolkit/postprocessing/__init__.py
+++ b/spiketoolkit/postprocessing/__init__.py
@@ -1,6 +1,6 @@
 from .postprocessing_tools import get_unit_waveforms, get_unit_templates, get_unit_max_channels, get_unit_amplitudes,\
     compute_unit_pca_scores, export_to_phy, set_unit_properties_by_max_channel_properties,\
-    compute_channel_spiking_activity
+    compute_channel_spiking_activity, compute_unit_coms
 
 from .features import compute_unit_template_features, get_template_features_list
 

--- a/spiketoolkit/postprocessing/__init__.py
+++ b/spiketoolkit/postprocessing/__init__.py
@@ -1,6 +1,6 @@
 from .postprocessing_tools import get_unit_waveforms, get_unit_templates, get_unit_max_channels, get_unit_amplitudes,\
     compute_unit_pca_scores, export_to_phy, set_unit_properties_by_max_channel_properties,\
-    compute_channel_spiking_activity, compute_unit_coms
+    compute_channel_spiking_activity, compute_unit_centers_of_mass
 
 from .features import compute_unit_template_features, get_template_features_list
 

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -254,11 +254,7 @@ def get_unit_waveforms(recording, sorting, unit_ids=None, channel_ids=None, retu
                     times_in_chunk = times[spike_time_idxs]
                 n_spikes[i] += len(times_in_chunk)
                 times_in_chunk_units.append(times_in_chunk)
-
-                #assert np.all(times_in_chunk >= chunk['istart']) and np.all(times_in_chunk < chunk['iend'])
             times_in_all_chunks.append(times_in_chunk_units)
-
-        # wf_chunk_idxs = np.zeros(len(unit_ids), dtype='int')
 
         if n_jobs == 1:
             for ii in chunk_iter:
@@ -878,7 +874,7 @@ def compute_channel_spiking_activity(recording, channel_ids=None, detect_thresho
     return spike_rates, spike_amplitudes
 
 
-def compute_unit_coms(recording, sorting, unit_ids=None, num_channels=10, **kwargs):
+def compute_unit_centers_of_mass(recording, sorting, unit_ids=None, num_channels=10, **kwargs):
     '''
     Computes the center of mass (COM) of a unit based on the template amplitudes.
 
@@ -924,7 +920,7 @@ def compute_unit_coms(recording, sorting, unit_ids=None, num_channels=10, **kwar
 
     Returns
     -------
-    coms: list
+    centers_of_mass: list
         List of int containing extracted COMs for each unit
     '''
 

--- a/spiketoolkit/sortingcomponents/detection.py
+++ b/spiketoolkit/sortingcomponents/detection.py
@@ -1,12 +1,15 @@
 import scipy.signal as ss
 from joblib import Parallel, delayed
 import spikeextractors as se
+from ..postprocessing.postprocessing_tools import divide_recording_into_time_chunks
 import itertools
+from tqdm import tqdm
 import numpy as np
 
 
 def detect_spikes(recording, channel_ids=None, detect_threshold=5, n_pad_ms=2, upsample=1, detect_sign=-1,
-                  min_diff_samples=5, align=True, start_frame=None, end_frame=None, n_jobs=1, verbose=False):
+                  min_diff_samples=5, align=True, start_frame=None, end_frame=None, n_jobs=1,
+                  chunk_size=None, chunk_mb=500, verbose=False):
     '''
     Detects spikes per channel.
     Parameters
@@ -33,19 +36,22 @@ def detect_spikes(recording, channel_ids=None, detect_threshold=5, n_pad_ms=2, u
         End frame end frame for detection
     n_jobs: int
         Number of jobs when parallel
+    chunk_size: int
+        Size of chunks in number of samples. If None, it is automatically calculated
+    chunk_mb: int
+        Size of chunks in Mb (default 500 Mb)
+    verbose: bool
+                If True output is verbose
 
     Returns
     -------
     sorting_detected: SortingExtractor
         The sorting extractor object with the detected spikes. Unit ids are the same as channel ids and units have the
-        'channel' property to specify which channel they correspond to
+        'channel' property to specify which channel they correspond to. The sorting extractor also has the `spike_rate`
+        and `spike_amplitude` properties.
     '''
-    spike_times = []
-    spike_amplitudes = []
-    labels = []
     n_pad_samples = int(n_pad_ms * recording.get_sampling_frequency() / 1000)
 
-    # compute spike rates
     if start_frame is None:
         start_frame = 0
     if end_frame is None:
@@ -57,116 +63,359 @@ def detect_spikes(recording, channel_ids=None, detect_threshold=5, n_pad_ms=2, u
         assert np.all([ch in recording.get_channel_ids() for ch in channel_ids]), "Not all 'channel_ids' are in the" \
                                                                                   "recording."
 
-    if not recording.check_if_dumpable():
-        if n_jobs > 1:
-            n_jobs = 0
-            print("RecordingExtractor is not dumpable and can't be processedin parallel")
-            rec_arg = recording
-        else:
-            rec_arg = recording
+    if n_jobs is None:
+        n_jobs = 1
+    if n_jobs == 0:
+        n_jobs = 1
+
+    if start_frame != 0 or end_frame != recording.get_num_frames():
+        recording_sub = se.SubRecordingExtractor(recording, start_frame=start_frame, end_frame=end_frame)
     else:
-        rec_arg = recording.make_serialized_dict()
+        recording_sub = recording
+
+    num_frames = recording_sub.get_num_frames()
+
+    # set chunk size
+    if chunk_size is not None:
+        chunk_size = int(chunk_size)
+    elif chunk_mb is not None:
+        n_bytes = np.dtype(recording.get_dtype()).itemsize
+        max_size = int(chunk_mb * 1e6)  # set Mb per chunk
+        chunk_size = max_size // (recording.get_num_channels() * n_bytes)
 
     if n_jobs > 1:
-        output = Parallel(n_jobs=n_jobs)(delayed(_detect_and_align_peaks_single_channel)
-                                         (rec_arg, ch, detect_threshold, detect_sign,
-                                          n_pad_samples, upsample, min_diff_samples, align, start_frame, end_frame,
-                                          verbose)
-                                         for ch in channel_ids)
-        for o in output:
-            spike_times.append(o[0])
-            spike_amplitudes.append(o[1])
-            labels.append(o[2])
+        chunk_size /= n_jobs
+
+    # chunk_size = num_bytes_per_chunk / num_bytes_per_frame
+    chunks = divide_recording_into_time_chunks(
+        num_frames=num_frames,
+        chunk_size=chunk_size,
+        padding_size=0
+    )
+    n_chunk = len(chunks)
+
+    if verbose:
+        print(f"Number of chunks: {len(chunks)} - Number of jobs: {n_jobs}")
+
+    if verbose and n_jobs == 1:
+        chunk_iter = tqdm(range(n_chunk), ascii=True, desc="Detecting spikes in chunks")
     else:
-        for ch in channel_ids:
-            peak_times, peak_val, label = _detect_and_align_peaks_single_channel(recording, ch, detect_threshold,
-                                                                                 detect_sign, n_pad_samples, upsample,
-                                                                                 min_diff_samples, align, start_frame,
-                                                                                 end_frame, verbose)
-            spike_times.append(peak_times)
-            spike_amplitudes.append(peak_val)
-            labels.append(label)
+        chunk_iter = range(n_chunk)
+
+    if not recording_sub.check_if_dumpable():
+        if n_jobs > 1:
+            n_jobs = 1
+            print("RecordingExtractor is not dumpable and can't be processed in parallel")
+        rec_arg = recording_sub
+    else:
+        if n_jobs > 1:
+            rec_arg = recording_sub.dump_to_dict()
+        else:
+            rec_arg = recording_sub
+
+    all_channel_times = [[] for ii in range(len(channel_ids))]
+    all_channel_amps = [[] for ii in range(len(channel_ids))]
+
+    if n_jobs > 1:
+        output = Parallel(n_jobs=n_jobs)(delayed(_detect_and_align_peaks_chunk)
+                                         (ii, rec_arg, chunks, channel_ids, detect_threshold,
+                                                              detect_sign, n_pad_samples, upsample, min_diff_samples,
+                                                              align, verbose)
+                                         for ii in chunk_iter)
+        for ii, (times_ii, amps_ii) in enumerate(output):
+            for i, ch in enumerate(channel_ids):
+                times = times_ii[i]
+                amps = amps_ii[i]
+                all_channel_amps[i].append(amps)
+                all_channel_times[i].append(times)
+    else:
+        for ii in chunk_iter:
+            times_ii, amps_ii = _detect_and_align_peaks_chunk(ii, rec_arg, chunks, channel_ids, detect_threshold,
+                                                              detect_sign, n_pad_samples, upsample, min_diff_samples,
+                                                              align, False)
+
+            for i, ch in enumerate(channel_ids):
+                times = times_ii[i]
+                amps = amps_ii[i]
+                all_channel_amps[i].append(amps)
+                all_channel_times[i].append(times)
+
+    if len(chunks) > 1:
+        times_list = []
+        amp_list = []
+        for i_ch in range(len(channel_ids)):
+            times_concat = np.concatenate([all_channel_times[i_ch][ch] for ch in range(len(chunks))],
+                                           axis=0)
+            times_list.append(times_concat)
+            amps_concat = np.concatenate([all_channel_amps[i_ch][ch] for ch in range(len(chunks))],
+                                          axis=0)
+            amp_list.append(amps_concat)
+    else:
+        times_list = [times[0] for times in all_channel_times]
+        amp_list = [amps[0] for amps in all_channel_amps]
+
+    labels_list = [[ch] * len(times) for (ch, times) in zip(channel_ids, times_list)]
 
     # create sorting extractor
     sorting = se.NumpySortingExtractor()
-    labels_flat = np.array(list(itertools.chain(*labels)))
-    times_flat = np.array(list(itertools.chain(*spike_times)))
+    labels_flat = np.array(list(itertools.chain(*labels_list)))
+    times_flat = np.array(list(itertools.chain(*times_list)))
     sorting.set_times_labels(times=times_flat, labels=labels_flat)
+    sorting.set_sampling_frequency(recording.get_sampling_frequency())
 
     duration = (end_frame - start_frame) / recording.get_sampling_frequency()
 
     for i_u, u in enumerate(sorting.get_unit_ids()):
         sorting.set_unit_property(u, 'channel', u)
-        sorting.set_unit_property(u, 'spike_amplitude', np.median(spike_amplitudes[i_u]))
+        amps = amp_list[i_u]
+        if len(amps) > 0:
+            sorting.set_unit_property(u, 'spike_amplitude', np.median(amp_list[i_u]))
+        else:
+            sorting.set_unit_property(u, 'spike_amplitude', 0)
         sorting.set_unit_property(u, 'spike_rate', len(sorting.get_unit_spike_train(u)) / duration)
 
     return sorting
 
 
-def _detect_and_align_peaks_single_channel(rec_arg, channel, n_std, detect_sign, n_pad, upsample, min_diff_samples,
-                                           align, start_frame, end_frame, verbose):
+def _detect_and_align_peaks_chunk(ii, rec_arg, chunks, channel_ids, detect_threshold, detect_sign, n_pad, upsample,
+                                  min_diff_samples, align, verbose):
+    chunk = chunks[ii]
+
     if verbose:
-        print(f'Detecting spikes on channel {channel}')
+        print(f"Chunk {ii + 1}: detecting spikes")
     if isinstance(rec_arg, dict):
         recording = se.load_extractor_from_dict(rec_arg)
     else:
         recording = rec_arg
-    trace = np.squeeze(recording.get_traces(channel_ids=channel, start_frame=start_frame, end_frame=end_frame))
-    if detect_sign == -1:
-        thresh = -n_std * np.median(np.abs(trace) / 0.6745)
-        idx_spikes = np.where(trace < thresh)[0]
-    elif detect_sign == 1:
-        thresh = n_std * np.median(np.abs(trace) / 0.6745)
-        idx_spikes = np.where(trace > thresh)[0]
-    else:
-        thresh = n_std * np.median(np.abs(trace) / 0.6745)
-        idx_spikes = np.where((trace > thresh) | (trace < -thresh))[0]
-    intervals = np.diff(idx_spikes)
-    sp_times = []
-    sp_amplitudes = []
 
-    for i_t, diff in enumerate(intervals):
-        if diff > min_diff_samples or i_t == len(intervals) - 1:
-            idx_spike = idx_spikes[i_t]
+    traces = recording.get_traces(start_frame=chunk['istart'],
+                                  end_frame=chunk['iend'])
 
-            if align:
-                if idx_spike - n_pad > 0 and idx_spike + n_pad < len(trace):
-                    spike = trace[idx_spike - n_pad:idx_spike + n_pad]
-                    t_spike = np.arange(idx_spike - n_pad, idx_spike + n_pad)
-                elif idx_spike - n_pad < 0:
-                    spike = trace[:idx_spike + n_pad]
-                    spike = np.pad(spike, (np.abs(idx_spike - n_pad), 0), 'constant')
-                    t_spike = np.arange(idx_spike + n_pad)
-                    t_spike = np.pad(t_spike, (np.abs(idx_spike - n_pad), 0), 'constant')
-                elif idx_spike + n_pad > len(trace):
-                    spike = trace[idx_spike - n_pad:]
-                    spike = np.pad(spike, (0, idx_spike + n_pad - len(trace)), 'constant')
-                    t_spike = np.arange(idx_spike - n_pad, len(trace))
-                    t_spike = np.pad(t_spike, (0, idx_spike + n_pad - len(trace)), 'constant')
+    sp_times = [[] for ii in range(len(channel_ids))]
+    sp_amplitudes = [[] for ii in range(len(channel_ids))]
 
-                if upsample > 1:
-                    spike_up = ss.resample(spike, int(upsample * len(spike)))
-                    t_spike_up = np.linspace(t_spike[0], t_spike[-1], num=len(spike_up))
+    for i, ch in enumerate(channel_ids):
+        trace = traces[i]
+        if detect_sign == -1:
+            thresh = -detect_threshold * np.median(np.abs(trace) / 0.6745)
+            idx_spikes = np.where(trace < thresh)[0]
+        elif detect_sign == 1:
+            thresh = detect_threshold * np.median(np.abs(trace) / 0.6745)
+            idx_spikes = np.where(trace > thresh)[0]
+        else:
+            thresh = detect_threshold * np.median(np.abs(trace) / 0.6745)
+            idx_spikes = np.where((trace > thresh) | (trace < -thresh))[0]
+        intervals = np.diff(idx_spikes)
+
+        for i_t, diff in enumerate(intervals):
+            if diff > min_diff_samples or i_t == len(intervals) - 1:
+                idx_spike = idx_spikes[i_t]
+
+                if align:
+                    if idx_spike - n_pad > 0 and idx_spike + n_pad < len(trace):
+                        spike = trace[idx_spike - n_pad:idx_spike + n_pad]
+                        t_spike = np.arange(idx_spike - n_pad, idx_spike + n_pad)
+                    elif idx_spike - n_pad < 0:
+                        spike = trace[:idx_spike + n_pad]
+                        spike = np.pad(spike, (np.abs(idx_spike - n_pad), 0), 'constant')
+                        t_spike = np.arange(idx_spike + n_pad)
+                        t_spike = np.pad(t_spike, (np.abs(idx_spike - n_pad), 0), 'constant')
+                    elif idx_spike + n_pad > len(trace):
+                        spike = trace[idx_spike - n_pad:]
+                        spike = np.pad(spike, (0, idx_spike + n_pad - len(trace)), 'constant')
+                        t_spike = np.arange(idx_spike - n_pad, len(trace))
+                        t_spike = np.pad(t_spike, (0, idx_spike + n_pad - len(trace)), 'constant')
+
+                    if upsample > 1:
+                        spike_up = ss.resample(spike, int(upsample * len(spike)))
+                        t_spike_up = np.linspace(t_spike[0], t_spike[-1], num=len(spike_up))
+                    else:
+                        spike_up = spike
+                        t_spike_up = t_spike
+                    if detect_sign == -1:
+                        peak_idx = np.argmin(spike_up)
+                        peak_val = np.min(spike_up)
+                    elif detect_sign == 1:
+                        peak_idx = np.argmax(spike_up)
+                        peak_val = np.max(spike_up)
+                    else:
+                        peak_idx = np.argmax(np.abs(spike_up))
+                        peak_val = np.max(np.abs(spike_up))
+
+                    min_time_up = t_spike_up[peak_idx]
+                    sp_times[i].append(int(min_time_up))
+                    sp_amplitudes[i].append(peak_val)
                 else:
-                    spike_up = spike
-                    t_spike_up = t_spike
-                if detect_sign == -1:
-                    peak_idx = np.argmin(spike_up)
-                    peak_val = np.min(spike_up)
-                elif detect_sign == 1:
-                    peak_idx = np.argmax(spike_up)
-                    peak_val = np.max(spike_up)
-                else:
-                    peak_idx = np.argmax(np.abs(spike_up))
-                    peak_val = np.max(np.abs(spike_up))
+                    sp_times[i].append(idx_spike)
+                    sp_amplitudes[i].append(trace[idx_spike])
 
-                min_time_up = t_spike_up[peak_idx]
-                sp_times.append(int(min_time_up))
-                sp_amplitudes.append(peak_val)
-            else:
-                sp_times.append(idx_spike)
-                sp_amplitudes.append(trace[idx_spike])
+    return sp_times, sp_amplitudes
 
-    labels = [channel] * len(sp_times)
-
-    return sp_times, sp_amplitudes, labels
+# def detect_spikes(recording, channel_ids=None, detect_threshold=5, n_pad_ms=2, upsample=1, detect_sign=-1,
+#                   min_diff_samples=5, align=True, start_frame=None, end_frame=None, n_jobs=1, verbose=False):
+#     '''
+#     Detects spikes per channel.
+#     Parameters
+#     ----------
+#     recording: RecordingExtractor
+#         The recording extractor object
+#     channel_ids: list or None
+#         List of channels to perform detection. If None all channels are used
+#     detect_threshold: float
+#         Threshold in MAD to detect peaks
+#     n_pad_ms: float
+#         Time in ms to find absolute peak around detected peak
+#     upsample: int
+#         The detected waveforms are upsampled 'upsample' times (default=1)
+#     detect_sign: int
+#         Sign of the detection: -1 (negative), 1 (positive), 0 (both)
+#     min_diff_samples: int
+#         Minimum interval to skip consecutive spikes (default=5)
+#     align: bool
+#         If True, spike times are aligned on the peak
+#     start_frame: int
+#         Start frame for detection
+#     end_frame: int
+#         End frame end frame for detection
+#     n_jobs: int
+#         Number of jobs when parallel
+#     Returns
+#     -------
+#     sorting_detected: SortingExtractor
+#         The sorting extractor object with the detected spikes. Unit ids are the same as channel ids and units have the
+#         'channel' property to specify which channel they correspond to
+#     '''
+#     spike_times = []
+#     spike_amplitudes = []
+#     labels = []
+#     n_pad_samples = int(n_pad_ms * recording.get_sampling_frequency() / 1000)
+#
+#     # compute spike rates
+#     if start_frame is None:
+#         start_frame = 0
+#     if end_frame is None:
+#         end_frame = recording.get_num_frames()
+#
+#     if channel_ids is None:
+#         channel_ids = recording.get_channel_ids()
+#     else:
+#         assert np.all([ch in recording.get_channel_ids() for ch in channel_ids]), "Not all 'channel_ids' are in the" \
+#                                                                                   "recording."
+#
+#     if not recording.check_if_dumpable():
+#         if n_jobs > 1:
+#             n_jobs = 0
+#             print("RecordingExtractor is not dumpable and can't be processedin parallel")
+#             rec_arg = recording
+#         else:
+#             rec_arg = recording
+#     else:
+#         rec_arg = recording.make_serialized_dict()
+#
+#     if n_jobs > 1:
+#         output = Parallel(n_jobs=n_jobs)(delayed(_detect_and_align_peaks_single_channel)
+#                                          (rec_arg, ch, detect_threshold, detect_sign,
+#                                           n_pad_samples, upsample, min_diff_samples, align, start_frame, end_frame,
+#                                           verbose)
+#                                          for ch in channel_ids)
+#         for o in output:
+#             spike_times.append(o[0])
+#             spike_amplitudes.append(o[1])
+#             labels.append(o[2])
+#     else:
+#         for ch in channel_ids:
+#             peak_times, peak_val, label = _detect_and_align_peaks_single_channel(recording, ch, detect_threshold,
+#                                                                                  detect_sign, n_pad_samples, upsample,
+#                                                                                  min_diff_samples, align, start_frame,
+#                                                                                  end_frame, verbose)
+#             spike_times.append(peak_times)
+#             spike_amplitudes.append(peak_val)
+#             labels.append(label)
+#
+#     # create sorting extractor
+#     sorting = se.NumpySortingExtractor()
+#     labels_flat = np.array(list(itertools.chain(*labels)))
+#     times_flat = np.array(list(itertools.chain(*spike_times)))
+#     sorting.set_times_labels(times=times_flat, labels=labels_flat)
+#
+#     duration = (end_frame - start_frame) / recording.get_sampling_frequency()
+#
+#     for i_u, u in enumerate(sorting.get_unit_ids()):
+#         sorting.set_unit_property(u, 'channel', u)
+#         amps = spike_amplitudes[i_u]
+#         if len(amps) > 0:
+#             sorting.set_unit_property(u, 'spike_amplitude', np.median(spike_amplitudes[i_u]))
+#         else:
+#             sorting.set_unit_property(u, 'spike_amplitude', 0)
+#         sorting.set_unit_property(u, 'spike_rate', len(sorting.get_unit_spike_train(u)) / duration)
+#
+#     return sorting
+#
+#
+# def _detect_and_align_peaks_single_channel(rec_arg, channel, n_std, detect_sign, n_pad, upsample, min_diff_samples,
+#                                            align, start_frame, end_frame, verbose):
+#     if verbose:
+#         print(f'Detecting spikes on channel {channel}')
+#     if isinstance(rec_arg, dict):
+#         recording = se.load_extractor_from_dict(rec_arg)
+#     else:
+#         recording = rec_arg
+#     trace = np.squeeze(recording.get_traces(channel_ids=channel, start_frame=start_frame, end_frame=end_frame))
+#     if detect_sign == -1:
+#         thresh = -n_std * np.median(np.abs(trace) / 0.6745)
+#         idx_spikes = np.where(trace < thresh)[0]
+#     elif detect_sign == 1:
+#         thresh = n_std * np.median(np.abs(trace) / 0.6745)
+#         idx_spikes = np.where(trace > thresh)[0]
+#     else:
+#         thresh = n_std * np.median(np.abs(trace) / 0.6745)
+#         idx_spikes = np.where((trace > thresh) | (trace < -thresh))[0]
+#     intervals = np.diff(idx_spikes)
+#     sp_times = []
+#     sp_amplitudes = []
+#
+#     for i_t, diff in enumerate(intervals):
+#         if diff > min_diff_samples or i_t == len(intervals) - 1:
+#             idx_spike = idx_spikes[i_t]
+#
+#             if align:
+#                 if idx_spike - n_pad > 0 and idx_spike + n_pad < len(trace):
+#                     spike = trace[idx_spike - n_pad:idx_spike + n_pad]
+#                     t_spike = np.arange(idx_spike - n_pad, idx_spike + n_pad)
+#                 elif idx_spike - n_pad < 0:
+#                     spike = trace[:idx_spike + n_pad]
+#                     spike = np.pad(spike, (np.abs(idx_spike - n_pad), 0), 'constant')
+#                     t_spike = np.arange(idx_spike + n_pad)
+#                     t_spike = np.pad(t_spike, (np.abs(idx_spike - n_pad), 0), 'constant')
+#                 elif idx_spike + n_pad > len(trace):
+#                     spike = trace[idx_spike - n_pad:]
+#                     spike = np.pad(spike, (0, idx_spike + n_pad - len(trace)), 'constant')
+#                     t_spike = np.arange(idx_spike - n_pad, len(trace))
+#                     t_spike = np.pad(t_spike, (0, idx_spike + n_pad - len(trace)), 'constant')
+#
+#                 if upsample > 1:
+#                     spike_up = ss.resample(spike, int(upsample * len(spike)))
+#                     t_spike_up = np.linspace(t_spike[0], t_spike[-1], num=len(spike_up))
+#                 else:
+#                     spike_up = spike
+#                     t_spike_up = t_spike
+#                 if detect_sign == -1:
+#                     peak_idx = np.argmin(spike_up)
+#                     peak_val = np.min(spike_up)
+#                 elif detect_sign == 1:
+#                     peak_idx = np.argmax(spike_up)
+#                     peak_val = np.max(spike_up)
+#                 else:
+#                     peak_idx = np.argmax(np.abs(spike_up))
+#                     peak_val = np.max(np.abs(spike_up))
+#
+#                 min_time_up = t_spike_up[peak_idx]
+#                 sp_times.append(int(min_time_up))
+#                 sp_amplitudes.append(peak_val)
+#             else:
+#                 sp_times.append(idx_spike)
+#                 sp_amplitudes.append(trace[idx_spike])
+#
+#     labels = [channel] * len(sp_times)
+#
+#     return sp_times, sp_amplitudes, labels

--- a/spiketoolkit/tests/test_postprocessing.py
+++ b/spiketoolkit/tests/test_postprocessing.py
@@ -394,4 +394,4 @@ def test_compute_features():
 
 
 if __name__ == '__main__':
-    test_compute_com()
+    test_spiking_activity()

--- a/spiketoolkit/tests/test_postprocessing.py
+++ b/spiketoolkit/tests/test_postprocessing.py
@@ -4,7 +4,7 @@ from spiketoolkit.tests.utils import create_signal_with_known_waveforms
 import spikeextractors as se
 from spiketoolkit.postprocessing import get_unit_waveforms, get_unit_templates, get_unit_amplitudes, \
     get_unit_max_channels, set_unit_properties_by_max_channel_properties, compute_unit_pca_scores, export_to_phy, \
-    compute_unit_template_features
+    compute_unit_template_features, compute_channel_spiking_activity, compute_unit_coms
 from spiketoolkit.preprocessing import remove_bad_channels
 import pandas
 import os
@@ -200,6 +200,98 @@ def test_amplitudes():
 
 
 @pytest.mark.implemented
+def test_spiking_activity():
+    n_jobs = [0, 2]
+    num_channels = 32
+    folder = 'test'
+    for n in n_jobs:
+        print('N jobs', n)
+        if os.path.isdir(folder):
+            shutil.rmtree(folder)
+        rec, sort = se.example_datasets.toy_example(num_channels=num_channels, dumpable=True, dump_folder=folder)
+
+        rates_simple, amps_simple = compute_channel_spiking_activity(rec, method='simple', n_jobs=n,
+                                                                     save_property_or_features=False)
+        assert len(rates_simple) == num_channels and len(amps_simple) == num_channels
+        assert 'spike_rate' not in rec.get_shared_channel_property_names()
+        assert 'spike_amplitude' not in rec.get_shared_channel_property_names()
+
+        rates_detection, amps_detection = compute_channel_spiking_activity(rec, method='detection', n_jobs=n)
+
+        assert len(rates_detection) == num_channels and len(amps_detection) == num_channels
+        assert 'spike_rate' in rec.get_shared_channel_property_names()
+        assert 'spike_amplitude' in rec.get_shared_channel_property_names()
+
+        shutil.rmtree(folder)
+
+
+@pytest.mark.notimplemented
+def test_compute_pca_scores():
+    num_channels = 32
+    folder = 'test'
+    n_jobs = [0, 2]
+    memmap = [True, False]
+    for n in n_jobs:
+        for m in memmap:
+            print('N jobs', n, 'memmap', m)
+
+            if os.path.isdir(folder):
+                shutil.rmtree(folder)
+            rec, sort = se.example_datasets.toy_example(num_channels=num_channels, dumpable=True, dump_folder=folder)
+
+            pca_scores = compute_unit_pca_scores(rec, sort, n_comp=5, memmap=m, n_jobs=n,
+                                                 save_property_or_features=False)
+            for pc in pca_scores:
+                assert pc.shape[-1] == 5
+            assert 'pca_scores' not in sort.get_shared_unit_spike_feature_names()
+
+            pca_scores = compute_unit_pca_scores(rec, sort, channel_ids=[0, 1, 2, 3, 4],
+                                                 max_channels_per_waveforms=3, n_comp=3, memmap=m, n_jobs=n)
+            for pc in pca_scores:
+                assert pc.shape[-1] == 3
+            assert 'pca_scores' in sort.get_shared_unit_spike_feature_names()
+            assert 'pca_scores_channel_idxs' in sort.get_shared_unit_property_names()
+            shutil.rmtree(folder)
+
+
+@pytest.mark.notimplemented
+def test_compute_com():
+    num_channels = 32
+    folder = 'test'
+    n_jobs = [0, 2]
+    locations = np.zeros((num_channels, 2))
+    radius = 100
+    # create circular locations
+    for i in np.arange(num_channels):
+        angle = 2*np.pi / num_channels * i
+        locations[i, 0] = np.cos(angle) * radius
+        locations[i, 1] = np.sin(angle) * radius
+
+    memmap = [True, False]
+    for n in n_jobs:
+        for m in memmap:
+            print('N jobs', n, 'memmap', m)
+
+            if os.path.isdir(folder):
+                shutil.rmtree(folder)
+            rec, sort = se.example_datasets.toy_example(num_channels=num_channels, dumpable=True, dump_folder=folder)
+            rec.set_channel_locations(locations)
+
+            coms = compute_unit_coms(rec, sort, num_channels=None, memmap=m, n_jobs=n,
+                                     save_property_or_features=False)
+            for com in coms:
+                assert np.linalg.norm(com) <= radius
+            assert 'com' not in sort.get_shared_unit_property_names()
+
+            coms = compute_unit_coms(rec, sort, num_channels=5, memmap=m, n_jobs=n)
+            for com in coms:
+                assert np.linalg.norm(com) <= radius
+            assert 'com' in sort.get_shared_unit_property_names()
+
+            shutil.rmtree(folder)
+
+
+@pytest.mark.implemented
 def test_export_to_phy():
     folder = 'test'
     if os.path.isdir(folder):
@@ -301,10 +393,5 @@ def test_compute_features():
     assert np.all([fk in features.keys() for fk in features_df.keys()])
 
 
-@pytest.mark.notimplemented
-def test_compute_pca_scores():
-    pass
-
-
 if __name__ == '__main__':
-    test_export_to_phy()
+    test_compute_com()

--- a/spiketoolkit/tests/test_postprocessing.py
+++ b/spiketoolkit/tests/test_postprocessing.py
@@ -4,7 +4,7 @@ from spiketoolkit.tests.utils import create_signal_with_known_waveforms
 import spikeextractors as se
 from spiketoolkit.postprocessing import get_unit_waveforms, get_unit_templates, get_unit_amplitudes, \
     get_unit_max_channels, set_unit_properties_by_max_channel_properties, compute_unit_pca_scores, export_to_phy, \
-    compute_unit_template_features, compute_channel_spiking_activity, compute_unit_coms
+    compute_unit_template_features, compute_channel_spiking_activity, compute_unit_centers_of_mass
 from spiketoolkit.preprocessing import remove_bad_channels
 import pandas
 import os
@@ -255,7 +255,7 @@ def test_compute_pca_scores():
 
 
 @pytest.mark.notimplemented
-def test_compute_com():
+def test_compute_centers_of_mass():
     num_channels = 32
     folder = 'test'
     n_jobs = [0, 2]
@@ -277,13 +277,13 @@ def test_compute_com():
             rec, sort = se.example_datasets.toy_example(num_channels=num_channels, dumpable=True, dump_folder=folder)
             rec.set_channel_locations(locations)
 
-            coms = compute_unit_coms(rec, sort, num_channels=None, memmap=m, n_jobs=n,
-                                     save_property_or_features=False)
+            coms = compute_unit_centers_of_mass(rec, sort, num_channels=None, memmap=m, n_jobs=n,
+                                                save_property_or_features=False)
             for com in coms:
                 assert np.linalg.norm(com) <= radius
             assert 'com' not in sort.get_shared_unit_property_names()
 
-            coms = compute_unit_coms(rec, sort, num_channels=5, memmap=m, n_jobs=n)
+            coms = compute_unit_centers_of_mass(rec, sort, num_channels=5, memmap=m, n_jobs=n)
             for com in coms:
                 assert np.linalg.norm(com) <= radius
             assert 'com' in sort.get_shared_unit_property_names()

--- a/spiketoolkit/tests/test_sortingcomponents.py
+++ b/spiketoolkit/tests/test_sortingcomponents.py
@@ -1,10 +1,11 @@
 import spikeextractors as se
 import spiketoolkit as st
 import numpy as np
-
+import shutil
 
 def test_detection():
-    rec, sort = se.example_datasets.toy_example(num_channels=4, duration=20, seed=0)
+    folder = 'test'
+    rec, sort = se.example_datasets.toy_example(num_channels=4, duration=20, seed=0, dumpable=True, dump_folder=folder)
 
     # negative
     sort_d_n = st.sortingcomponents.detect_spikes(rec)
@@ -12,6 +13,10 @@ def test_detection():
 
     assert 'channel' in sort_d_n.get_shared_unit_property_names()
     assert 'channel' in sort_dp_n.get_shared_unit_property_names()
+    assert 'spike_rate' in sort_d_n.get_shared_unit_property_names()
+    assert 'spike_rate' in sort_dp_n.get_shared_unit_property_names()
+    assert 'spike_amplitude' in sort_d_n.get_shared_unit_property_names()
+    assert 'spike_amplitude' in sort_dp_n.get_shared_unit_property_names()
 
     for u in sort_d_n.get_unit_ids():
         assert np.array_equal(sort_d_n.get_unit_spike_train(u), sort_dp_n.get_unit_spike_train(u))
@@ -22,6 +27,10 @@ def test_detection():
 
     assert 'channel' in sort_d_p.get_shared_unit_property_names()
     assert 'channel' in sort_dp_p.get_shared_unit_property_names()
+    assert 'spike_rate' in sort_d_p.get_shared_unit_property_names()
+    assert 'spike_rate' in sort_dp_p.get_shared_unit_property_names()
+    assert 'spike_amplitude' in sort_d_p.get_shared_unit_property_names()
+    assert 'spike_amplitude' in sort_dp_p.get_shared_unit_property_names()
 
     for u in sort_d_p.get_unit_ids():
         assert np.array_equal(sort_d_p.get_unit_spike_train(u), sort_dp_p.get_unit_spike_train(u))
@@ -32,9 +41,15 @@ def test_detection():
 
     assert 'channel' in sort_d_b.get_shared_unit_property_names()
     assert 'channel' in sort_dp_b.get_shared_unit_property_names()
+    assert 'spike_rate' in sort_d_b.get_shared_unit_property_names()
+    assert 'spike_rate' in sort_dp_b.get_shared_unit_property_names()
+    assert 'spike_amplitude' in sort_d_b.get_shared_unit_property_names()
+    assert 'spike_amplitude' in sort_dp_b.get_shared_unit_property_names()
 
     for u in sort_d_b.get_unit_ids():
         assert np.array_equal(sort_d_b.get_unit_spike_train(u), sort_dp_b.get_unit_spike_train(u))
+
+    shutil.rmtree(folder)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Add function to compute center of mass (COM) based on units' amplitudes `compute_unit_centers_of mass`

- Refractor of `compute_channel_spiking_activity`: instead of setting the `activity` property, it now sets both the `spike_rate` and `spike_amplitude` properties (required a modification of the `st.sortingcomponents.detect_spikes` function). In addition, a chunking mechanism for computing channel activity and detecting spikes is implemented, making parallel processing more efficient.

- Add tests for: `compute_unit_pca_scores`, `compute_channel_spiking_activity`, and `compute_unit_coms`

**NOTE**: this PR will break the spikewidgets `plot_activity_map`. With the next spiketoolkit and spikewidgets release we'll need to use `spiketoolkit>=0.7.2` as requirement