### PR TITLE
Limit num_knn to total possible neighbors when computing noise overlap metric

### DIFF
--- a/spiketoolkit/validation/quality_metric_classes/noise_overlap.py
+++ b/spiketoolkit/validation/quality_metric_classes/noise_overlap.py
@@ -99,7 +99,7 @@ class NoiseOverlap(QualityMetric):
             num_match = 0
             total = 0
             for j in range(num_clips * 2):
-                for k in range(1, num_knn + 1):
+                for k in range(1, min(num_knn + 1,num_spikes[i_u])):
                     ind = indices[j][k]
                     if group_id[j] == group_id[ind]:
                         num_match = num_match + 1

--- a/spiketoolkit/validation/quality_metric_classes/noise_overlap.py
+++ b/spiketoolkit/validation/quality_metric_classes/noise_overlap.py
@@ -87,7 +87,7 @@ class NoiseOverlap(QualityMetric):
             all_features = _compute_pca_features(all_clips.reshape((num_clips * 2,
                                                                     num_channels_wfs * num_samples_wfs)), num_features)
             num_all_clips=len(all_clips)
-            distances, indices = NearestNeighbors(n_neighbors=min(num_knn+1,num_all_clips), algorithm='auto').fit(
+            distances, indices = NearestNeighbors(n_neighbors=min(num_knn + 1, num_all_clips - 1), algorithm='auto').fit(
                 all_features.T).kneighbors()
 
             group_id = np.zeros((num_clips * 2))
@@ -96,7 +96,7 @@ class NoiseOverlap(QualityMetric):
             num_match = 0
             total = 0
             for j in range(num_clips * 2):
-                for k in range(1, min(num_knn + 1,num_total_samples)):
+                for k in range(1, min(num_knn + 1, num_all_clips - 1)):
                     ind = indices[j][k]
                     if group_id[j] == group_id[ind]:
                         num_match = num_match + 1

--- a/spiketoolkit/validation/quality_metric_classes/noise_overlap.py
+++ b/spiketoolkit/validation/quality_metric_classes/noise_overlap.py
@@ -3,6 +3,7 @@ from copy import copy
 from .utils.thresholdcurator import ThresholdCurator
 from .quality_metric import QualityMetric
 import spiketoolkit as st
+import spikemetrics.metrics as metrics
 from spikemetrics.utils import printProgressBar
 from collections import OrderedDict
 from sklearn.neighbors import NearestNeighbors
@@ -34,6 +35,9 @@ class NoiseOverlap(QualityMetric):
             max_spikes_per_unit=max_spikes_per_unit_for_noise_overlap,
             **kwargs
         )
+
+        # number of spikes for each unit
+        num_spikes = st.validation.quality_metrics.compute_num_spikes(self._metric_data._sorting)
 
         if seed is not None:
             np.random.seed(seed)
@@ -86,7 +90,7 @@ class NoiseOverlap(QualityMetric):
             all_features = _compute_pca_features(all_clips.reshape((num_clips * 2,
                                                                     num_channels_wfs * num_samples_wfs)), num_features)
 
-            distances, indices = NearestNeighbors(n_neighbors=num_knn + 1, algorithm='auto').fit(
+            distances, indices = NearestNeighbors(n_neighbors=min(num_knn+1,num_spikes[i_u]), algorithm='auto').fit(
                 all_features.T).kneighbors()
 
             group_id = np.zeros((num_clips * 2))

--- a/spiketoolkit/validation/quality_metric_classes/noise_overlap.py
+++ b/spiketoolkit/validation/quality_metric_classes/noise_overlap.py
@@ -36,9 +36,6 @@ class NoiseOverlap(QualityMetric):
             **kwargs
         )
 
-        # number of spikes for each unit
-        num_spikes = st.validation.quality_metrics.compute_num_spikes(self._metric_data._sorting)
-
         if seed is not None:
             np.random.seed(seed)
 
@@ -89,8 +86,8 @@ class NoiseOverlap(QualityMetric):
             num_samples_wfs = all_clips.shape[2]
             all_features = _compute_pca_features(all_clips.reshape((num_clips * 2,
                                                                     num_channels_wfs * num_samples_wfs)), num_features)
-
-            distances, indices = NearestNeighbors(n_neighbors=min(num_knn+1,num_spikes[i_u]), algorithm='auto').fit(
+            num_all_clips=len(all_clips)
+            distances, indices = NearestNeighbors(n_neighbors=min(num_knn+1,num_all_clips), algorithm='auto').fit(
                 all_features.T).kneighbors()
 
             group_id = np.zeros((num_clips * 2))
@@ -99,7 +96,7 @@ class NoiseOverlap(QualityMetric):
             num_match = 0
             total = 0
             for j in range(num_clips * 2):
-                for k in range(1, min(num_knn + 1,num_spikes[i_u])):
+                for k in range(1, min(num_knn + 1,num_total_samples)):
                     ind = indices[j][k]
                     if group_id[j] == group_id[ind]:
                         num_match = num_match + 1


### PR DESCRIPTION
Pull request related to this issue: https://github.com/SpikeInterface/spiketoolkit/issues/425#issue-761961334