### PR TITLE
RemoveArtifacts: Copy traces to fix write access

### DIFF
--- a/spiketoolkit/preprocessing/remove_artifacts.py
+++ b/spiketoolkit/preprocessing/remove_artifacts.py
@@ -23,6 +23,7 @@ class RemoveArtifactsRecording(BasePreprocessorRecordingExtractor):
         pad = [int(self._ms_before * self.get_sampling_frequency() / 1000),
                int(self._ms_after * self.get_sampling_frequency() / 1000)]
 
+        traces = traces.copy()
         for trig in triggers:
             if trig - pad[0] > 0 and trig + pad[1] < end_frame - start_frame:
                 traces[:, trig - pad[0]:trig + pad[1]] = 0


### PR DESCRIPTION
Make a copy of memmapped traces in memory to be able to access it for editing when the traces are requested using the get_traces() method

Fixes issue #448 - ValueError: assignment destination is read-only
