### PR TITLE
Simple fast high pass filter

### DIFF
--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1297,7 +1297,7 @@ def export_to_phy(recording, sorting, output_folder, compute_pc_features=True,
     filter_flag = True if not "filter_flag" in kwargs else kwargs['filter_flag']
     if not recording.is_filtered and filter_flag:
         print("Warning: recording is not filtered! It's recommended to filter the recording before exporting to phy.\n"
-              "You can run spiketoolkit.preprocessing.bandpass_filter(recording, cache_to_file=True)")
+              "You can run spiketoolkit.preprocessing.bandpass_filter(recording)")
 
     if len(sorting.get_unit_ids()) == 0:
         raise Exception("No non-empty units in the sorting result, can't save to phy.")

--- a/spiketoolkit/preprocessing/bandpass_filter.py
+++ b/spiketoolkit/preprocessing/bandpass_filter.py
@@ -85,7 +85,7 @@ def _create_filter_kernel(N, sampling_frequency, freq_min, freq_max, freq_wid=10
 
 
 def bandpass_filter(recording, freq_min=300, freq_max=6000, freq_wid=1000, filter_type='fft', order=3,
-                    chunk_size=30000, cache_to_file=False, cache_chunks=False, dtype=None):
+                    chunk_size=30000, cache_chunks=False, dtype=None):
     '''
     Performs a lazy filter on the recording extractor traces.
 
@@ -106,8 +106,6 @@ def bandpass_filter(recording, freq_min=300, freq_max=6000, freq_wid=1000, filte
         Order of the filter (if 'butter').
     chunk_size: int
         The chunk size to be used for the filtering.
-    cache_to_file: bool (default False).
-        If True, filtered traces are computed and cached all at once on disk in temp file 
     cache_chunks: bool (default False).
         If True then each chunk is cached in memory (in a dict)
     dtype: dtype
@@ -118,9 +116,6 @@ def bandpass_filter(recording, freq_min=300, freq_max=6000, freq_wid=1000, filte
     filter_recording: BandpassFilterRecording
         The filtered recording extractor object
     '''
-    if cache_to_file:
-        assert not cache_chunks, 'if cache_to_file cache_chunks should be False'
-    
     bpf_recording = BandpassFilterRecording(
         recording=recording,
         freq_min=freq_min,
@@ -132,7 +127,4 @@ def bandpass_filter(recording, freq_min=300, freq_max=6000, freq_wid=1000, filte
         cache_chunks=cache_chunks,
         dtype=dtype
     )
-    if cache_to_file:
-        return se.CacheRecordingExtractor(bpf_recording, chunk_size=chunk_size)
-    else:
-        return bpf_recording
+    return bpf_recording

--- a/spiketoolkit/preprocessing/filterrecording.py
+++ b/spiketoolkit/preprocessing/filterrecording.py
@@ -34,7 +34,7 @@ class FilterRecording(BasePreprocessorRecordingExtractor):
         BasePreprocessorRecordingExtractor.__init__(self, recording_base)
 
     # avoid filtering one sample
-    def get_dtype(self):
+    def get_dtype(self, return_scaled=True):
         return self._dtype
 
     @check_get_traces_args

--- a/spiketoolkit/preprocessing/highpass_filter.py
+++ b/spiketoolkit/preprocessing/highpass_filter.py
@@ -87,7 +87,7 @@ def _create_filter_kernel(N, sampling_frequency, freq_min, freq_wid=1000):
 
 
 def highpass_filter(recording, freq_min=300, freq_wid=1000, filter_type='butter', order=1,
-                    chunk_size=30000, cache_to_file=False, cache_chunks=False, dtype=None):
+                    chunk_size=30000, cache_chunks=False, dtype=None):
     '''
     Performs a lazy filter on the recording extractor traces.
 
@@ -97,8 +97,6 @@ def highpass_filter(recording, freq_min=300, freq_wid=1000, filter_type='butter'
         The recording extractor to be filtered.
     freq_min: int or float
         High-pass cutoff frequency.
-    freq_max: int or float
-        Low-pass cutoff frequency.
     freq_wid: int or float
         Width of the filter (when type is 'fft').
     filter_type: str
@@ -108,8 +106,6 @@ def highpass_filter(recording, freq_min=300, freq_wid=1000, filter_type='butter'
         Order of the filter (if 'butter').
     chunk_size: int
         The chunk size to be used for the filtering.
-    cache_to_file: bool (default False).
-        If True, filtered traces are computed and cached all at once on disk in temp file 
     cache_chunks: bool (default False).
         If True then each chunk is cached in memory (in a dict)
     dtype: dtype
@@ -120,10 +116,7 @@ def highpass_filter(recording, freq_min=300, freq_wid=1000, filter_type='butter'
     filter_recording: HighpassFilterRecording
         The filtered recording extractor object
     '''
-    if cache_to_file:
-        assert not cache_chunks, 'if cache_to_file cache_chunks should be False'
-    
-    bpf_recording = HighpassFilterRecording(
+    hp_recording = HighpassFilterRecording(
         recording=recording,
         freq_min=freq_min,
         freq_wid=freq_wid,
@@ -133,7 +126,4 @@ def highpass_filter(recording, freq_min=300, freq_wid=1000, filter_type='butter'
         cache_chunks=cache_chunks,
         dtype=dtype
     )
-    if cache_to_file:
-        return se.CacheRecordingExtractor(bpf_recording, chunk_size=chunk_size)
-    else:
-        return bpf_recording
+    return hp_recording

--- a/spiketoolkit/preprocessing/highpass_filter.py
+++ b/spiketoolkit/preprocessing/highpass_filter.py
@@ -1,0 +1,139 @@
+from .filterrecording import FilterRecording
+import numpy as np
+import scipy.signal as ss
+from scipy import special
+import spikeextractors as se
+
+
+class HighpassFilterRecording(FilterRecording):
+    preprocessor_name = 'HighpassFilter'
+
+    def __init__(self, recording, freq_min=300, freq_wid=1000, filter_type='butter', order=1,
+                 chunk_size=30000, cache_chunks=False, dtype=None):
+        self._freq_min = freq_min
+        self._freq_wid = freq_wid
+        self._type = filter_type
+        self._order = order
+        self._chunk_size = chunk_size
+        self._padding = 3000
+
+        if self._type == 'butter':
+            fn = recording.get_sampling_frequency() / 2.
+            band = self._freq_min / fn
+
+            self._b, self._a = ss.butter(self._order, band, btype='highpass')
+
+            if not np.all(np.abs(np.roots(self._a)) < 1):
+                raise ValueError('Filter is not stable')
+        elif self._type == 'fft':
+            self._kernel = _create_filter_kernel(
+                self._chunk_size+2*self._padding,
+                recording.get_sampling_frequency(),
+                self._freq_min, self._freq_wid
+            )
+            self._kernel = self._kernel[0:(chunk_size+2*self._padding)//2+1]  # because this is the DFT of real data
+        else:
+            raise NotImplementedError('filter type {} not implemented.'.format(filter_type))
+            
+        FilterRecording.__init__(self, recording=recording, chunk_size=chunk_size, cache_chunks=cache_chunks,
+                                 dtype=dtype)
+        self.is_filtered = True
+        self._kwargs = {'recording': recording.make_serialized_dict(), 'freq_min': freq_min,
+                        'freq_wid': freq_wid, 'filter_type': filter_type, 'order': order,
+                        'chunk_size': chunk_size, 'cache_chunks': cache_chunks}
+
+    def filter_chunk(self, *, start_frame, end_frame, channel_ids):
+        padding = 3000
+        i1 = start_frame - self._padding
+        i2 = end_frame + self._padding
+        padded_chunk = self._read_chunk(i1, i2, channel_ids)
+        filtered_padded_chunk = self._do_filter(padded_chunk)
+        return filtered_padded_chunk[:, start_frame - i1:end_frame - i1]
+
+    def _do_filter(self, chunk):
+        sampling_frequency = self._recording.get_sampling_frequency()
+        M = chunk.shape[0]
+        chunk2 = chunk
+        # Do the actual filtering with a DFT with real input
+        if self._type == 'fft':
+            chunk_fft = np.fft.rfft(chunk2)
+            chunk_fft = chunk_fft * np.tile(self._kernel, (M, 1))
+            chunk_filtered = np.fft.irfft(chunk_fft)
+        elif self._type == 'butter':
+            chunk_filtered = ss.filtfilt(self._b, self._a, chunk2, axis=1)
+
+        return chunk_filtered
+
+
+def _create_filter_kernel(N, sampling_frequency, freq_min, freq_wid=1000):
+    # Matches ahb's code /matlab/processors/ms_bandpass_filter.m
+    # improved ahb, changing tanh to erf, correct -3dB pts  6/14/16
+    T = N / sampling_frequency  # total time
+    df = 1 / T  # frequency grid
+    relwid = 3.0  # relative bottom-end roll-off width param, kills low freqs by factor 1e-5.
+
+    k_inds = np.arange(0, N)
+    k_inds = np.where(k_inds <= (N + 1) / 2, k_inds, k_inds - N)
+
+    fgrid = df * k_inds
+    absf = np.abs(fgrid)
+
+    val = np.ones(fgrid.shape)
+    if freq_min != 0:
+        val = val * (1 + special.erf(relwid * (absf - freq_min) / freq_min)) / 2
+        val = np.where(np.abs(k_inds) < 0.1, 0, val)  # kill DC part exactly
+    val = np.sqrt(val)  # note sqrt of filter func to apply to spectral intensity not ampl
+    return val
+
+
+def highpass_filter(recording, freq_min=300, freq_wid=1000, filter_type='butter', order=1,
+                    chunk_size=30000, cache_to_file=False, cache_chunks=False, dtype=None):
+    '''
+    Performs a lazy filter on the recording extractor traces.
+
+    Parameters
+    ----------
+    recording: RecordingExtractor
+        The recording extractor to be filtered.
+    freq_min: int or float
+        High-pass cutoff frequency.
+    freq_max: int or float
+        Low-pass cutoff frequency.
+    freq_wid: int or float
+        Width of the filter (when type is 'fft').
+    filter_type: str
+        'fft' or 'butter'. The 'fft' filter uses a kernel in the frequency domain. The 'butter' filter uses
+        scipy butter and filtfilt functions.
+    order: int
+        Order of the filter (if 'butter').
+    chunk_size: int
+        The chunk size to be used for the filtering.
+    cache_to_file: bool (default False).
+        If True, filtered traces are computed and cached all at once on disk in temp file 
+    cache_chunks: bool (default False).
+        If True then each chunk is cached in memory (in a dict)
+    dtype: dtype
+        The dtype of the traces
+
+    Returns
+    -------
+    filter_recording: HighpassFilterRecording
+        The filtered recording extractor object
+    '''
+    if cache_to_file:
+        assert not cache_chunks, 'if cache_to_file cache_chunks should be False'
+    
+    bpf_recording = HighpassFilterRecording(
+        recording=recording,
+        freq_min=freq_min,
+        freq_wid=freq_wid,
+        filter_type=filter_type,
+        order=order,
+        chunk_size=chunk_size,
+        cache_chunks=cache_chunks,
+        dtype=dtype
+    )
+    if cache_to_file:
+        return se.CacheRecordingExtractor(bpf_recording, chunk_size=chunk_size)
+    else:
+        return bpf_recording

--- a/spiketoolkit/preprocessing/normalize_by_quantile.py
+++ b/spiketoolkit/preprocessing/normalize_by_quantile.py
@@ -23,7 +23,7 @@ class NormalizeByQuantileRecording(BasePreprocessorRecordingExtractor):
         N = self._recording.get_num_frames()
         random_ints = np.random.RandomState(seed=seed).randint(0, N - chunk_size, size=num_chunks)
         chunk_list = []
-        for ff in random_ints:
+        for ff in np.sort(random_ints):
             chunk = self._recording.get_traces(start_frame=ff,
                                                end_frame=ff + chunk_size)
             chunk_list.append(chunk)

--- a/spiketoolkit/preprocessing/notch_filter.py
+++ b/spiketoolkit/preprocessing/notch_filter.py
@@ -33,7 +33,7 @@ class NotchFilterRecording(FilterRecording):
         return chunk_filtered
 
 
-def notch_filter(recording, freq=3000, q=30, chunk_size=30000, cache_to_file=False, cache_chunks=False):
+def notch_filter(recording, freq=3000, q=30, chunk_size=30000, cache_chunks=False):
     '''
     Performs a notch filter on the recording extractor traces using scipy iirnotch function.
 
@@ -47,8 +47,6 @@ def notch_filter(recording, freq=3000, q=30, chunk_size=30000, cache_to_file=Fal
         The quality factor of the notch filter.
     chunk_size: int
         The chunk size to be used for the filtering.
-    cache_to_file: bool (default False).
-        If True, filtered traces are computed and cached all at once on disk in temp file 
     cache_chunks: bool (default False).
         If True then each chunk is cached in memory (in a dict)
     Returns
@@ -57,9 +55,6 @@ def notch_filter(recording, freq=3000, q=30, chunk_size=30000, cache_to_file=Fal
         The notch-filtered recording extractor object
     '''
 
-    if cache_to_file:
-        assert not cache_chunks, 'if cache_to_file cache_chunks should be False'
-    
     notch_recording = NotchFilterRecording(
         recording=recording,
         freq=freq,
@@ -67,7 +62,4 @@ def notch_filter(recording, freq=3000, q=30, chunk_size=30000, cache_to_file=Fal
         chunk_size=chunk_size,
         cache_chunks=cache_chunks,
     )
-    if cache_to_file:
-        return se.CacheRecordingExtractor(notch_recording, chunk_size=chunk_size)
-    else:
-        return notch_recording
+    return notch_recording

--- a/spiketoolkit/preprocessing/preprocessinglist.py
+++ b/spiketoolkit/preprocessing/preprocessinglist.py
@@ -1,3 +1,4 @@
+from .highpass_filter import highpass_filter, HighpassFilterRecording
 from .bandpass_filter import bandpass_filter, BandpassFilterRecording
 from .notch_filter import notch_filter, NotchFilterRecording
 from .whiten import whiten, WhitenRecording
@@ -13,6 +14,7 @@ from .blank_saturation import blank_saturation, BlankSaturationRecording
 from .center import center, CenterRecording
 
 preprocessers_full_list = [
+    HighpassFilterRecording,
     BandpassFilterRecording,
     NotchFilterRecording,
     WhitenRecording,

--- a/spiketoolkit/tests/test_postprocessing.py
+++ b/spiketoolkit/tests/test_postprocessing.py
@@ -325,13 +325,11 @@ def test_export_to_phy():
     assert not (Path('phy_no_amp_feat') / 'pc_features.npy').is_file()
     assert not (Path('phy_no_amp_feat') / 'pc_feature_ind.npy').is_file()
 
-    sort_phy = se.PhySortingExtractor('phy', load_waveforms=True)
-    sort_phyg = se.PhySortingExtractor('phy_group', load_waveforms=True)
+    sort_phy = se.PhySortingExtractor('phy')
+    sort_phyg = se.PhySortingExtractor('phy_group')
 
     assert np.allclose(sort_phy.get_unit_spike_train(0), sort.get_unit_spike_train(sort.get_unit_ids()[0]))
     assert np.allclose(sort_phyg.get_unit_spike_train(2), sort.get_unit_spike_train(sort.get_unit_ids()[2]))
-    assert sort_phy.get_unit_spike_features(1, 'waveforms').shape[1] == 8
-    assert sort_phyg.get_unit_spike_features(3, 'waveforms').shape[1] == 4
 
     rec.set_channel_groups([0, 0, 0, 0, 1, 1, 1, 1])
     recrm = remove_bad_channels(rec, [1, 2, 5])

--- a/spiketoolkit/tests/test_preprocessing.py
+++ b/spiketoolkit/tests/test_preprocessing.py
@@ -4,8 +4,8 @@ import pytest
 import shutil
 from spiketoolkit.tests.utils import check_signal_power_signal1_below_signal2
 from spiketoolkit.preprocessing import bandpass_filter, blank_saturation, center, clip, common_reference, \
-    normalize_by_quantile, notch_filter, rectify, remove_artifacts, remove_bad_channels, resample, transform, \
-    whiten
+    highpass_filter, normalize_by_quantile, notch_filter, rectify, remove_artifacts, remove_bad_channels, resample, \
+    transform, whiten
 from spikeextractors.testing import check_dumping
 
 
@@ -27,13 +27,6 @@ def test_bandpass_filter():
     assert check_signal_power_signal1_below_signal2(rec_sci.get_traces(), rec.get_traces(), freq_range=[6000, 10000],
                                                     fs=rec.get_sampling_frequency())
 
-    rec_cache = bandpass_filter(rec, freq_min=3000, freq_max=6000, filter_type='butter', order=3, cache_to_file=True)
-
-    assert check_signal_power_signal1_below_signal2(rec_cache.get_traces(), rec.get_traces(), freq_range=[1000, 3000],
-                                                    fs=rec.get_sampling_frequency())
-    assert check_signal_power_signal1_below_signal2(rec_cache.get_traces(), rec.get_traces(), freq_range=[6000, 10000],
-                                                    fs=rec.get_sampling_frequency())
-
     traces = rec.get_traces().astype('uint16')
     rec_u = se.NumpyRecordingExtractor(traces, sampling_frequency=rec.get_sampling_frequency())
     rec_fu = bandpass_filter(rec_u, freq_min=5000, freq_max=10000, filter_type='fft')
@@ -45,34 +38,6 @@ def test_bandpass_filter():
     assert not str(rec_fu.get_dtype()).startswith('u')
 
     check_dumping(rec_fft)
-    check_dumping(rec_cache)
-
-    shutil.rmtree('test')
-
-
-@pytest.mark.implemented
-def test_bandpass_filter_with_cache():
-    rec, sort = se.example_datasets.toy_example(dump_folder='test', dumpable=True, duration=2, num_channels=4, seed=0)
-
-    rec_filtered = bandpass_filter(rec, freq_min=5000, freq_max=10000, cache_to_file=True, chunk_size=10000)
-
-    rec_filtered2 = bandpass_filter(rec, freq_min=5000, freq_max=10000, cache_to_file=True, chunk_size=None)
-
-    rec_filtered3 = bandpass_filter(rec, freq_min=5000, freq_max=10000, cache_chunks=True, chunk_size=10000)
-    rec_filtered3.get_traces()
-    assert rec_filtered3._filtered_cache_chunks.get('0') is not None
-
-    rec_filtered4 = bandpass_filter(rec, freq_min=5000, freq_max=10000, cache_chunks=True, chunk_size=None)
-
-    assert np.allclose(rec_filtered.get_traces(), rec_filtered2.get_traces(), rtol=1e-02, atol=1e-02)
-    assert np.allclose(rec_filtered.get_traces(), rec_filtered3.get_traces(), rtol=1e-02, atol=1e-02)
-    assert np.allclose(rec_filtered.get_traces(), rec_filtered4.get_traces(), rtol=1e-02, atol=1e-02)
-
-    check_dumping(rec_filtered)
-    check_dumping(rec_filtered2)
-    check_dumping(rec_filtered3)
-    check_dumping(rec_filtered4)
-
     shutil.rmtree('test')
 
 
@@ -162,6 +127,33 @@ def test_common_reference():
     check_dumping(rec_cmr_int16)
     shutil.rmtree('test')
 
+
+@pytest.mark.implemented
+def test_highpass_filter():
+    rec, sort = se.example_datasets.toy_example(dump_folder='test', dumpable=True, duration=2, num_channels=4, seed=0)
+
+    rec_fft = highpass_filter(rec, freq_min=5000, filter_type='fft')
+
+    assert check_signal_power_signal1_below_signal2(rec_fft.get_traces(), rec.get_traces(), freq_range=[1000, 5000],
+                                                    fs=rec.get_sampling_frequency())
+
+    rec_sci = bandpass_filter(rec, freq_min=3000, freq_max=6000, filter_type='butter', order=3)
+
+    assert check_signal_power_signal1_below_signal2(rec_sci.get_traces(), rec.get_traces(), freq_range=[1000, 3000],
+                                                    fs=rec.get_sampling_frequency())
+
+    traces = rec.get_traces().astype('uint16')
+    rec_u = se.NumpyRecordingExtractor(traces, sampling_frequency=rec.get_sampling_frequency())
+    rec_fu = bandpass_filter(rec_u, freq_min=5000, freq_max=10000, filter_type='fft')
+
+    assert check_signal_power_signal1_below_signal2(rec_fu.get_traces(), rec_u.get_traces(), freq_range=[1000, 5000],
+                                                    fs=rec.get_sampling_frequency())
+    assert check_signal_power_signal1_below_signal2(rec_fu.get_traces(), rec_u.get_traces(), freq_range=[10000, 15000],
+                                                    fs=rec.get_sampling_frequency())
+    assert not str(rec_fu.get_dtype()).startswith('u')
+
+    check_dumping(rec_fft)
+    shutil.rmtree('test')
 
 @pytest.mark.notimplemented
 def test_norm_by_quantile():

--- a/spiketoolkit/validation/quality_metric_classes/metric_data.py
+++ b/spiketoolkit/validation/quality_metric_classes/metric_data.py
@@ -146,7 +146,6 @@ class MetricData:
                 recording=recording,
                 freq_min=freq_min,
                 freq_max=freq_max,
-                cache_to_file=True,
             )
         else:
             recording_filter = recording


### PR DESCRIPTION
Runs fast as simple Butterworth order 1 filter, use it to remove slow, LFP-like fluctutations (also has fft version). Faster than the bandpass. Note that generally the fft based method seems slower (it's default in the bandpass).