### PR TITLE
Add artifact removal modes (linear & cubic interpolation)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     package_data={},
     install_requires=[
         'numpy',
-        'spikeextractors>=0.9.4',
+        'spikeextractors>=0.9.3',
         'spikemetrics>=0.2.3',
         'spikefeatures',
         'scikit-learn',

--- a/spiketoolkit/preprocessing/remove_artifacts.py
+++ b/spiketoolkit/preprocessing/remove_artifacts.py
@@ -133,7 +133,11 @@ class RemoveArtifactsRecording(BasePreprocessorRecordingExtractor):
 
 def remove_artifacts(recording, triggers, ms_before=0.5, ms_after=3, mode = 'zeros', fit_sample_spacing = 1):
     '''
-    Removes stimulation artifacts from recording extractor traces. Artifact periods are zeroed-out.
+    Removes stimulation artifacts from recording extractor traces. By default, 
+    artifact periods are zeroed-out (mode = 'zeros'). This is only recommended 
+    for traces that are centered around zero (e.g. through a prior highpass
+    filter); if this is not the case, linear and cubic interpolation modes are
+    also available, controlled by the 'mode' input argument.
 
     Parameters
     ----------
@@ -145,6 +149,33 @@ def remove_artifacts(recording, triggers, ms_before=0.5, ms_after=3, mode = 'zer
         Time interval in ms to remove before the trigger events
     ms_after: float
         Time interval in ms to remove after the trigger events
+    mode: string
+        Determines what artifacts are replaced by. Can be one of the following:
+            
+        'zeros' (default): Artifacts are replaced by zeros. 
+        
+        'linear': Replacement are obtained through Linear interpolation between 
+        the trace before and after the artifact. 
+        If the trace starts or ends with an artifact period, the gap is filled 
+        with the closest available value before or after the artifact.
+        
+        'cubic': Cubic spline interpolation between the trace before and after
+        the artifact, referenced to evenly spaced fit points before and after
+        the artifact. This is an option thatcan be helpful if there are 
+        significant LFP effects around the time of the artifact, but visual 
+        inspection of fit behaviour with your chosen settings is recommended.
+        The spacing of fit points is controlled by 'fit_sample_spacing', with 
+        greater spacing between points leading to a fit that is less sensitive 
+        to high frequency fluctuations but at the cost of a less smooth 
+        continuation of the trace.
+        If the trace starts or ends with an artifact , the gap is filled with 
+        the closest available value before or after the artifact.            
+    fit_sample_spacing: float
+        Determines the spacing (in ms) of reference points for the cubic spline
+        fit if mode = 'cubic'. Default = 1ms. Note: The actual fit samples are 
+        the median of the 5 data points around the time of each sample point to
+        avoid excessive influence from hyper-local fluctuations.
+        
 
     Returns
     -------

--- a/spiketoolkit/preprocessing/remove_artifacts.py
+++ b/spiketoolkit/preprocessing/remove_artifacts.py
@@ -2,12 +2,13 @@ from spikeextractors import RecordingExtractor
 from spikeextractors.extraction_tools import check_get_traces_args
 from .basepreprocessorrecording import BasePreprocessorRecordingExtractor
 import numpy as np
-import scipy as sp
+from scipy.interpolate import interp1d
+
 
 class RemoveArtifactsRecording(BasePreprocessorRecordingExtractor):
     preprocessor_name = 'RemoveArtifacts'
 
-    def __init__(self, recording, triggers, ms_before=0.5, ms_after=3.0, mode = 'zeros', fit_sample_spacing = 1):
+    def __init__(self, recording, triggers, ms_before=0.5, ms_after=3.0, mode='zeros', fit_sample_spacing=1.):
         self._triggers = np.array(triggers)
         self._ms_before = ms_before
         self._ms_after = ms_after
@@ -26,7 +27,7 @@ class RemoveArtifactsRecording(BasePreprocessorRecordingExtractor):
 
         pad = [int(self._ms_before * self.get_sampling_frequency() / 1000),
                int(self._ms_after * self.get_sampling_frequency() / 1000)]
-        
+
         traces = traces.copy()
         if self._mode == 'zeros':
             for trig in triggers:
@@ -39,100 +40,102 @@ class RemoveArtifactsRecording(BasePreprocessorRecordingExtractor):
                 elif trig + pad[1] >= end_frame - start_frame:
                     traces[:, trig - pad[0]:] = 0
         else:
-            
-            sample_freq         = self._recording.get_sampling_frequency()
-            
-            # generate indices for evenly spaced fit points before and after gap
-            fit_sample_range    = int(((sample_freq/1000) * self._fit_sample_spacing * 2) + 1)
-            fit_sample_interval = int(self._fit_sample_spacing * (sample_freq / 1000))
-            
-            fit_samples         = np.array(range(0,fit_sample_range,fit_sample_interval))
-            rev_fit_samples     = fit_sample_range - fit_samples
+            sample_freq = self._recording.get_sampling_frequency()
 
+            # generate indices for evenly spaced fit points before and after gap
+            fit_sample_range = int(((sample_freq / 1000) * self._fit_sample_spacing * 2) + 1)
+            fit_sample_interval = int(self._fit_sample_spacing * (sample_freq / 1000))
+
+            fit_samples = np.array(range(0, fit_sample_range, fit_sample_interval))
+            rev_fit_samples = fit_sample_range - fit_samples
+            triggers = np.array(triggers).astype(int)
             for trig in triggers:
-                pre_data_end_idx    = trig - pad[0] - 1
+                pre_data_end_idx = trig - pad[0] - 1
                 post_data_start_idx = trig + pad[1] + 1
-                
+
                 # Generate fit points from the sample points determined
-                pre_idx     = pre_data_end_idx - rev_fit_samples + 1
-                post_idx    = post_data_start_idx + fit_samples
-                
+                pre_idx = pre_data_end_idx - rev_fit_samples + 1
+                post_idx = post_data_start_idx + fit_samples
+
                 # Get indices of the gap to fill
-                gap_idx     = np.array(range(pre_data_end_idx + 1, post_data_start_idx + 0))
-                
+                gap_idx = np.array(range(pre_data_end_idx + 1, post_data_start_idx + 0))
+
                 # Make sure we are not going out of bounds
-                gap_idx     = gap_idx[gap_idx >= 0]
-                gap_idx     = gap_idx[gap_idx < len(traces[0])]
-                
+                gap_idx = gap_idx[gap_idx >= 0]
+                gap_idx = gap_idx[gap_idx < len(traces[0])]
+
                 # correct for out of bounds indices on both sides:
                 if np.max(post_idx) >= len(traces[0]):
                     post_idx = post_idx[post_idx < len(traces[0])]
-                
+
                 if np.min(pre_idx) < 0:
                     pre_idx = pre_idx[pre_idx >= 0]
-                
+
                 # fit x values                
-                all_idx  = np.hstack((pre_idx,post_idx))
-                
+                all_idx = np.hstack((pre_idx, post_idx))
+
                 # fit y values
-                interp_traces = traces[:,all_idx]
-                
+                interp_traces = traces[:, all_idx]
+
                 # Get the median value from 5 samples around each fit point
                 # for robustness to noise / small fluctuations
-                pre_vals = np.empty((0,len(traces)),'int32')
+                pre_vals = np.empty((0, len(traces)), 'int32')
                 for idx in iter(pre_idx):
                     if idx == pre_idx[-1]:
-                        idxs = np.array(range(idx-3,idx+1))
+                        idxs = np.array(range(idx - 3, idx + 1))
                     else:
-                        idxs = np.array(range(idx-2, idx+3))
-                    
+                        idxs = np.array(range(idx - 2, idx + 3))
+
                     if np.min(idx) < 0:
                         idx = idx[idx >= 0]
-                    
-                    median_vals = np.median(traces[:,idxs], axis = 1)
-                    pre_vals = np.vstack((pre_vals,median_vals))
-                    
-                post_vals = np.empty((0,len(traces)),'int32')
+
+                    median_vals = np.median(traces[:, idxs], axis=1)
+                    pre_vals = np.vstack((pre_vals, median_vals))
+
+                post_vals = np.empty((0, len(traces)), 'int32')
                 for idx in iter(post_idx):
                     if idx == post_idx[0]:
-                        idxs = np.array(range(idx,idx+4))
+                        idxs = np.array(range(idx, idx + 4))
                     else:
-                        idxs = np.array(range(idx-2, idx+3))
-                    
+                        idxs = np.array(range(idx - 2, idx + 3))
+
                     if np.max(idx) >= len(traces[0]):
                         idx = idx[idx < len(traces[0])]
-                    
-                    median_vals = np.median(traces[:,idxs], axis = 1)
-                    post_vals = np.vstack((post_vals,median_vals))
-                
+
+                    median_vals = np.median(traces[:, idxs], axis=1)
+                    post_vals = np.vstack((post_vals, median_vals))
+
                 interp_traces = np.vstack((pre_vals, post_vals)).T
-                
+
                 if (self._mode == 'cubic') & (len(all_idx) >= 5):
                     # Enough fit points present on either side to do cubic spline fit:
-                    interp_function     = sp.interpolate.interp1d(all_idx, interp_traces, self._mode, bounds_error = False, fill_value = 'extrapolate')
-                    traces[:,gap_idx]   = interp_function(gap_idx)
+                    interp_function = interp1d(all_idx, interp_traces, self._mode,
+                                               bounds_error=False,
+                                               fill_value='extrapolate')
+                    traces[:, gap_idx] = interp_function(gap_idx)
                 elif (self._mode == 'linear') & (len(all_idx) >= 2):
                     # Enough fit points present for a linear fit
-                    interp_function     = sp.interpolate.interp1d(all_idx, interp_traces, self._mode, bounds_error = False, fill_value = 'extrapolate')
-                    traces[:,gap_idx]   = interp_function(gap_idx)
+                    interp_function = interp1d(all_idx, interp_traces, self._mode, bounds_error=False,
+                                               fill_value='extrapolate')
+                    traces[:, gap_idx] = interp_function(gap_idx)
                 elif len(pre_idx) > len(post_idx):
                     # not enough fit points, fill with nearest neighbour on side with the most data points
-                    traces[:,gap_idx]   = np.repeat(traces[:,pre_idx[-1]]* np.ones((1,1)),len(gap_idx),0).T
+                    traces[:, gap_idx] = np.repeat(traces[:, pre_idx[-1]] * np.ones((1, 1)), len(gap_idx), 0).T
                 elif len(post_idx) > len(pre_idx):
                     # not enough fit points, fill with nearest neighbour on side with the most data points
-                    traces[:,gap_idx]   = np.repeat(traces[:,post_idx[0]]* np.ones((1,1)),len(gap_idx),0).T
+                    traces[:, gap_idx] = np.repeat(traces[:, post_idx[0]] * np.ones((1, 1)), len(gap_idx), 0).T
                 elif len(all_idx) > 0:
                     # not enough fit points, both sides tied for most data points, fill with last pre value
-                    traces[:,gap_idx]   = np.repeat(traces[:,pre_idx[-1]]* np.ones((1,1)),len(gap_idx),0).T
+                    traces[:, gap_idx] = np.repeat(traces[:, pre_idx[-1]] * np.ones((1, 1)), len(gap_idx), 0).T
                 else:
                     # No data to interpolate from on either side of gap;
                     # Fill with zeros
-                    traces[:,gap_idx] = 0
-                    
+                    traces[:, gap_idx] = 0
+
         return traces
 
 
-def remove_artifacts(recording, triggers, ms_before=0.5, ms_after=3, mode = 'zeros', fit_sample_spacing = 1):
+def remove_artifacts(recording, triggers, ms_before=0.5, ms_after=3, mode='zeros', fit_sample_spacing=1.):
     '''
     Removes stimulation artifacts from recording extractor traces. By default, 
     artifact periods are zeroed-out (mode = 'zeros'). This is only recommended 
@@ -150,27 +153,27 @@ def remove_artifacts(recording, triggers, ms_before=0.5, ms_after=3, mode = 'zer
         Time interval in ms to remove before the trigger events
     ms_after: float
         Time interval in ms to remove after the trigger events
-    mode: string
+    mode: str
         Determines what artifacts are replaced by. Can be one of the following:
             
-        'zeros' (default): Artifacts are replaced by zeros. 
+        - 'zeros' (default): Artifacts are replaced by zeros.
         
-        'linear': Replacement are obtained through Linear interpolation between 
-        the trace before and after the artifact. 
-        If the trace starts or ends with an artifact period, the gap is filled 
-        with the closest available value before or after the artifact.
+        - 'linear': Replacement are obtained through Linear interpolation between
+           the trace before and after the artifact.
+           If the trace starts or ends with an artifact period, the gap is filled
+           with the closest available value before or after the artifact.
         
-        'cubic': Cubic spline interpolation between the trace before and after
-        the artifact, referenced to evenly spaced fit points before and after
-        the artifact. This is an option thatcan be helpful if there are 
-        significant LFP effects around the time of the artifact, but visual 
-        inspection of fit behaviour with your chosen settings is recommended.
-        The spacing of fit points is controlled by 'fit_sample_spacing', with 
-        greater spacing between points leading to a fit that is less sensitive 
-        to high frequency fluctuations but at the cost of a less smooth 
-        continuation of the trace.
-        If the trace starts or ends with an artifact , the gap is filled with 
-        the closest available value before or after the artifact.            
+        - 'cubic': Cubic spline interpolation between the trace before and after
+           the artifact, referenced to evenly spaced fit points before and after
+           the artifact. This is an option thatcan be helpful if there are
+           significant LFP effects around the time of the artifact, but visual
+           inspection of fit behaviour with your chosen settings is recommended.
+           The spacing of fit points is controlled by 'fit_sample_spacing', with
+           greater spacing between points leading to a fit that is less sensitive
+           to high frequency fluctuations but at the cost of a less smooth
+           continuation of the trace.
+           If the trace starts or ends with an artifact, the gap is filled with
+           the closest available value before or after the artifact.
     fit_sample_spacing: float
         Determines the spacing (in ms) of reference points for the cubic spline
         fit if mode = 'cubic'. Default = 1ms. Note: The actual fit samples are 
@@ -185,5 +188,5 @@ def remove_artifacts(recording, triggers, ms_before=0.5, ms_after=3, mode = 'zer
 
     '''
     return RemoveArtifactsRecording(
-        recording=recording, triggers=triggers, ms_before=ms_before, 
-        ms_after=ms_after, mode = mode, fit_sample_spacing = fit_sample_spacing)
+        recording=recording, triggers=triggers, ms_before=ms_before,
+        ms_after=ms_after, mode=mode, fit_sample_spacing=fit_sample_spacing)

--- a/spiketoolkit/preprocessing/remove_artifacts.py
+++ b/spiketoolkit/preprocessing/remove_artifacts.py
@@ -2,18 +2,21 @@ from spikeextractors import RecordingExtractor
 from spikeextractors.extraction_tools import check_get_traces_args
 from .basepreprocessorrecording import BasePreprocessorRecordingExtractor
 import numpy as np
-
+import scipy as sp
 
 class RemoveArtifactsRecording(BasePreprocessorRecordingExtractor):
     preprocessor_name = 'RemoveArtifacts'
 
-    def __init__(self, recording, triggers, ms_before=0.5, ms_after=3.0):
+    def __init__(self, recording, triggers, ms_before=0.5, ms_after=3.0, mode = 'zeros', fit_sample_spacing = 1):
         self._triggers = np.array(triggers)
         self._ms_before = ms_before
         self._ms_after = ms_after
+        self._mode = mode
+        self._fit_sample_spacing = fit_sample_spacing
         BasePreprocessorRecordingExtractor.__init__(self, recording)
         self._kwargs = {'recording': recording.make_serialized_dict(), 'triggers': triggers,
-                        'ms_before': ms_before, 'ms_after': ms_after}
+                        'ms_before': ms_before, 'ms_after': ms_after, 'mode': mode,
+                        'fit_sample_spacing': fit_sample_spacing}
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
@@ -22,21 +25,113 @@ class RemoveArtifactsRecording(BasePreprocessorRecordingExtractor):
 
         pad = [int(self._ms_before * self.get_sampling_frequency() / 1000),
                int(self._ms_after * self.get_sampling_frequency() / 1000)]
-
+        
         traces = traces.copy()
-        for trig in triggers:
-            if trig - pad[0] > 0 and trig + pad[1] < end_frame - start_frame:
-                traces[:, trig - pad[0]:trig + pad[1]] = 0
-            elif trig - pad[0] <= 0 and trig + pad[1] >= end_frame - start_frame:
-                traces = 0
-            elif trig - pad[0] <= 0:
-                traces[:, :trig + pad[1]] = 0
-            elif trig + pad[1] >= end_frame - start_frame:
-                traces[:, trig - pad[0]:] = 0
+        if self._mode == 'zeros':
+            for trig in triggers:
+                if trig - pad[0] > 0 and trig + pad[1] < end_frame - start_frame:
+                    traces[:, trig - pad[0]:trig + pad[1]] = 0
+                elif trig - pad[0] <= 0 and trig + pad[1] >= end_frame - start_frame:
+                    traces = 0
+                elif trig - pad[0] <= 0:
+                    traces[:, :trig + pad[1]] = 0
+                elif trig + pad[1] >= end_frame - start_frame:
+                    traces[:, trig - pad[0]:] = 0
+        else:
+            
+            sample_freq         = self._recording.get_sampling_frequency()
+            
+            # generate indices for evenly spaced fit points before and after gap
+            fit_sample_range    = int(((sample_freq/1000) * self._fit_sample_spacing * 2) + 1)
+            fit_sample_interval = int(self._fit_sample_spacing * (sample_freq / 1000))
+            
+            fit_samples         = np.array(range(0,fit_sample_range,fit_sample_interval))
+            rev_fit_samples     = fit_sample_range - fit_samples
+
+            for trig in triggers:
+                pre_data_end_idx    = trig - pad[0] - 1
+                post_data_start_idx = trig + pad[1] + 1
+                
+                # Generate fit points from the sample points determined
+                pre_idx     = pre_data_end_idx - rev_fit_samples + 1
+                post_idx    = post_data_start_idx + fit_samples
+                
+                # Get indices of the gap to fill
+                gap_idx     = np.array(range(pre_data_end_idx + 1, post_data_start_idx + 0))
+                
+                # Make sure we are not going out of bounds
+                gap_idx     = gap_idx[gap_idx >= 0]
+                gap_idx     = gap_idx[gap_idx < len(traces[0])]
+                
+                # correct for out of bounds indices on both sides:
+                if np.max(post_idx) >= len(traces[0]):
+                    post_idx = post_idx[post_idx < len(traces[0])]
+                
+                if np.min(pre_idx) < 0:
+                    pre_idx = pre_idx[pre_idx >= 0]
+                
+                # fit x values                
+                all_idx  = np.hstack((pre_idx,post_idx))
+                
+                # fit y values
+                interp_traces = traces[:,all_idx]
+                
+                # Get the median value from 5 samples around each fit point
+                # for robustness to noise / small fluctuations
+                pre_vals = np.empty((0,len(traces)),'int32')
+                for idx in iter(pre_idx):
+                    if idx == pre_idx[-1]:
+                        idxs = np.array(range(idx-3,idx+1))
+                    else:
+                        idxs = np.array(range(idx-2, idx+3))
+                    
+                    if np.min(idx) < 0:
+                        idx = idx[idx >= 0]
+                    
+                    median_vals = np.median(traces[:,idxs], axis = 1)
+                    pre_vals = np.vstack((pre_vals,median_vals))
+                    
+                post_vals = np.empty((0,len(traces)),'int32')
+                for idx in iter(post_idx):
+                    if idx == post_idx[0]:
+                        idxs = np.array(range(idx,idx+4))
+                    else:
+                        idxs = np.array(range(idx-2, idx+3))
+                    
+                    if np.max(idx) >= len(traces[0]):
+                        idx = idx[idx < len(traces[0])]
+                    
+                    median_vals = np.median(traces[:,idxs], axis = 1)
+                    post_vals = np.vstack((post_vals,median_vals))
+                
+                interp_traces = np.vstack((pre_vals, post_vals)).T
+                
+                if (self._mode == 'cubic') & (len(all_idx) >= 5):
+                    # Enough fit points present on either side to do cubic spline fit:
+                    interp_function     = sp.interpolate.interp1d(all_idx, interp_traces, self._mode, bounds_error = False, fill_value = 'extrapolate')
+                    traces[:,gap_idx]   = interp_function(gap_idx)
+                elif (self._mode == 'linear') & (len(all_idx) >= 2):
+                    # Enough fit points present for a linear fit
+                    interp_function     = sp.interpolate.interp1d(all_idx, interp_traces, self._mode, bounds_error = False, fill_value = 'extrapolate')
+                    traces[:,gap_idx]   = interp_function(gap_idx)
+                elif len(pre_idx) > len(post_idx):
+                    # not enough fit points, fill with nearest neighbour on side with the most data points
+                    traces[:,gap_idx]   = np.repeat(traces[:,pre_idx[-1]]* np.ones((1,1)),len(gap_idx),0).T
+                elif len(post_idx) > len(pre_idx):
+                    # not enough fit points, fill with nearest neighbour on side with the most data points
+                    traces[:,gap_idx]   = np.repeat(traces[:,post_idx[0]]* np.ones((1,1)),len(gap_idx),0).T
+                elif len(all_idx) > 0:
+                    # not enough fit points, both sides tied for most data points, fill with last pre value
+                    traces[:,gap_idx]   = np.repeat(traces[:,pre_idx[-1]]* np.ones((1,1)),len(gap_idx),0).T
+                else:
+                    # No data to interpolate from on either side of gap;
+                    # Fill with zeros
+                    traces[:,gap_idx] = 0
+                    
         return traces
 
 
-def remove_artifacts(recording, triggers, ms_before=0.5, ms_after=3):
+def remove_artifacts(recording, triggers, ms_before=0.5, ms_after=3, mode = 'zeros', fit_sample_spacing = 1):
     '''
     Removes stimulation artifacts from recording extractor traces. Artifact periods are zeroed-out.
 
@@ -58,5 +153,5 @@ def remove_artifacts(recording, triggers, ms_before=0.5, ms_after=3):
 
     '''
     return RemoveArtifactsRecording(
-        recording=recording, triggers=triggers, ms_before=ms_before, ms_after=ms_after
-    )
+        recording=recording, triggers=triggers, ms_before=ms_before, 
+        ms_after=ms_after, mode = mode, fit_sample_spacing = fit_sample_spacing)

--- a/spiketoolkit/tests/test_preprocessing.py
+++ b/spiketoolkit/tests/test_preprocessing.py
@@ -200,6 +200,9 @@ def test_remove_artifacts():
     ms = 10
     ms_frames = int(ms * rec.get_sampling_frequency() / 1000)
 
+    traces_all_0_clean = rec.get_traces(start_frame=triggers[0] - ms_frames, end_frame=triggers[0] + ms_frames)
+    traces_all_1_clean = rec.get_traces(start_frame=triggers[1] - ms_frames, end_frame=triggers[1] + ms_frames)
+
     rec_rmart = remove_artifacts(rec, triggers, ms_before=10, ms_after=10)
     traces_all_0 = rec_rmart.get_traces(start_frame=triggers[0] - ms_frames, end_frame=triggers[0] + ms_frames)
     traces_short_0 = rec_rmart.get_traces(start_frame=triggers[0] - 10, end_frame=triggers[0] + 10)
@@ -210,6 +213,19 @@ def test_remove_artifacts():
     assert not np.any(traces_all_1)
     assert not np.any(traces_short_0)
     assert not np.any(traces_short_1)
+
+    rec_rmart_lin = remove_artifacts(rec, triggers, ms_before=10, ms_after=10, mode="linear")
+    traces_all_0 = rec_rmart_lin.get_traces(start_frame=triggers[0] - ms_frames, end_frame=triggers[0] + ms_frames)
+    traces_all_1 = rec_rmart_lin.get_traces(start_frame=triggers[1] - ms_frames, end_frame=triggers[1] + ms_frames)
+    assert not np.allclose(traces_all_0, traces_all_0_clean)
+    assert not np.allclose(traces_all_1, traces_all_1_clean)
+
+    rec_rmart_cub = remove_artifacts(rec, triggers, ms_before=10, ms_after=10, mode="cubic")
+    traces_all_0 = rec_rmart_cub.get_traces(start_frame=triggers[0] - ms_frames, end_frame=triggers[0] + ms_frames)
+    traces_all_1 = rec_rmart_cub.get_traces(start_frame=triggers[1] - ms_frames, end_frame=triggers[1] + ms_frames)
+
+    assert not np.allclose(traces_all_0, traces_all_0_clean)
+    assert not np.allclose(traces_all_1, traces_all_1_clean)
 
     check_dumping(rec_rmart)
     shutil.rmtree('test')


### PR DESCRIPTION
Add 'mode' input argument to remove_artifacts(). Default is 'zeros' (old behaviour). If 'linear', implements linear interpolation between pre and post artifact points. If 'cubic' - implements cubit spline interpolation.
Additional input 'fit_sample_spacing' determines how far apart sample points are taken for creating the spline fit that is used to fill in the gap (default is 1 ms). Shorter sample intervals lead to better continuation locally, but may lead to steeper fit slopes with more high frequency content.

Related to issue #451 
