### PR TITLE
Fix return scaled 

### DIFF
--- a/spiketoolkit/preprocessing/bandpass_filter.py
+++ b/spiketoolkit/preprocessing/bandpass_filter.py
@@ -32,11 +32,11 @@ class BandpassFilterRecording(FilterRecording):
                         'freq_wid': freq_wid, 'filter_type': filter_type, 'order': order,
                         'chunk_size': chunk_size, 'cache_chunks': cache_chunks}
 
-    def filter_chunk(self, *, start_frame, end_frame, channel_ids):
+    def filter_chunk(self, start_frame, end_frame, channel_ids, return_scaled):
         padding = 3000
         i1 = start_frame - padding
         i2 = end_frame + padding
-        padded_chunk = self._read_chunk(i1, i2, channel_ids)
+        padded_chunk = self._read_chunk(i1, i2, channel_ids, return_scaled)
         filtered_padded_chunk = self._do_filter(padded_chunk)
         return filtered_padded_chunk[:, start_frame - i1:end_frame - i1]
 

--- a/spiketoolkit/preprocessing/basepreprocessorrecording.py
+++ b/spiketoolkit/preprocessing/basepreprocessorrecording.py
@@ -14,6 +14,9 @@ class BasePreprocessorRecordingExtractor(RecordingExtractor):
         self.copy_epochs(recording)
         self.copy_times(recording)
 
+        # avoid rescaling twice
+        self.set_channel_gains(1)
+        self.set_channel_offsets(0)
 
         self.is_filtered = recording.is_filtered
         if hasattr(recording, "has_unscaled"):

--- a/spiketoolkit/preprocessing/blank_saturation.py
+++ b/spiketoolkit/preprocessing/blank_saturation.py
@@ -29,20 +29,24 @@ class BlankSaturationRecording(BasePreprocessorRecordingExtractor):
                 self._lower = False
             else:
                 self._lower = True
+        self.has_unscaled = False
+
         self._kwargs = {'recording': recording.make_serialized_dict(), 'threshold': threshold, 'seed': seed}
 
-    def _get_random_data_for_scaling(self, num_chunks=50, chunk_size=500, seed=0):
+    def _get_random_data_for_scaling(self, num_chunks=50, chunk_size=500, seed=0, return_scaled=True):
         N = self._recording.get_num_frames()
         random_ints = np.random.RandomState(seed=seed).randint(0, N - chunk_size, size=num_chunks)
         chunk_list = []
         for ff in random_ints:
             chunk = self._recording.get_traces(start_frame=ff,
-                                               end_frame=ff + chunk_size)
+                                               end_frame=ff + chunk_size, return_scaled=return_scaled)
             chunk_list.append(chunk)
         return np.concatenate(chunk_list, axis=1)
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None, return_scaled=True):
+        assert return_scaled, "'blank_saturation' only supports return_scaled=True"
+
         traces = self._recording.get_traces(channel_ids=channel_ids,
                                             start_frame=start_frame,
                                             end_frame=end_frame,

--- a/spiketoolkit/preprocessing/blank_saturation.py
+++ b/spiketoolkit/preprocessing/blank_saturation.py
@@ -33,13 +33,13 @@ class BlankSaturationRecording(BasePreprocessorRecordingExtractor):
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'threshold': threshold, 'seed': seed}
 
-    def _get_random_data_for_scaling(self, num_chunks=50, chunk_size=500, seed=0, return_scaled=True):
+    def _get_random_data_for_scaling(self, num_chunks=50, chunk_size=500, seed=0):
         N = self._recording.get_num_frames()
         random_ints = np.random.RandomState(seed=seed).randint(0, N - chunk_size, size=num_chunks)
         chunk_list = []
         for ff in random_ints:
             chunk = self._recording.get_traces(start_frame=ff,
-                                               end_frame=ff + chunk_size, return_scaled=return_scaled)
+                                               end_frame=ff + chunk_size)
             chunk_list.append(chunk)
         return np.concatenate(chunk_list, axis=1)
 

--- a/spiketoolkit/preprocessing/center.py
+++ b/spiketoolkit/preprocessing/center.py
@@ -33,12 +33,8 @@ class CenterRecording(TransformRecording):
             self._offset = -np.mean(traces, axis=1)
         else:
             self._offset = -np.median(traces, axis=1)
-        dtype = str(recording.get_dtype())
+        dtype = np.dtype(recording.get_dtype()).name
         if 'uint' in dtype:
-            if 'numpy' in dtype:
-                dtype = str(dtype).replace("<class '", "").replace("'>", "")
-                # drop 'numpy'
-                dtype = dtype.split('.')[1]
             dtype = dtype[1:]
         TransformRecording.__init__(self, recording, scalar=self._scalar, offset=self._offset, dtype=dtype)
         self._kwargs = {'recording': recording.make_serialized_dict(), 'mode': mode, 'seconds': seconds,

--- a/spiketoolkit/preprocessing/clip.py
+++ b/spiketoolkit/preprocessing/clip.py
@@ -14,10 +14,13 @@ class ClipRecording(BasePreprocessorRecordingExtractor):
         self._a_min = a_min
         self._a_max = a_max
         BasePreprocessorRecordingExtractor.__init__(self, recording)
+        self.has_unscaled = False
         self._kwargs = {'recording': recording.make_serialized_dict(), 'a_min': a_min, 'a_max': a_max}
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None, return_scaled=True):
+        assert return_scaled, "'clip' only supports return_scaled=True"
+
         traces = self._recording.get_traces(channel_ids=channel_ids,
                                             start_frame=start_frame,
                                             end_frame=end_frame,

--- a/spiketoolkit/preprocessing/common_reference.py
+++ b/spiketoolkit/preprocessing/common_reference.py
@@ -42,7 +42,8 @@ class CommonReferenceRecording(BasePreprocessorRecordingExtractor):
             if self._groups is None:
                 if self.verbose:
                     print('Common median reference using all channels')
-                traces = self._recording.get_traces(start_frame=start_frame, end_frame=end_frame)
+                traces = self._recording.get_traces(start_frame=start_frame, end_frame=end_frame,
+                                                    return_scaled=return_scaled)
                 traces = traces - np.median(traces, axis=0, keepdims=True)
                 return traces[channel_idxs].astype(self._dtype)
             else:
@@ -68,7 +69,8 @@ class CommonReferenceRecording(BasePreprocessorRecordingExtractor):
             if self.verbose:
                 print('Common average reference using all channels')
             if self._groups is None:
-                traces = self._recording.get_traces(start_frame=start_frame, end_frame=end_frame)
+                traces = self._recording.get_traces(start_frame=start_frame, end_frame=end_frame,
+                                                    return_scaled=return_scaled)
                 traces = traces - np.mean(traces, axis=0, keepdims=True)
                 return traces[channel_idxs].astype(self._dtype)
             else:

--- a/spiketoolkit/preprocessing/filterrecording.py
+++ b/spiketoolkit/preprocessing/filterrecording.py
@@ -62,10 +62,10 @@ class FilterRecording(BasePreprocessorRecordingExtractor):
         return filtered_chunk.astype(self._dtype)
 
     @abstractmethod
-    def filter_chunk(self, *, start_frame, end_frame, channel_ids):
+    def filter_chunk(self, *, start_frame, end_frame, channel_ids, return_scaled):
         raise NotImplementedError('filter_chunk not implemented')
 
-    def _read_chunk(self, i1, i2, channel_ids):
+    def _read_chunk(self, i1, i2, channel_ids, return_scaled=True):
         num_frames = self._recording.get_num_frames()
         if i1 < 0:
             i1b = 0
@@ -77,7 +77,7 @@ class FilterRecording(BasePreprocessorRecordingExtractor):
             i2b = i2
         chunk = np.zeros((len(channel_ids), i2 - i1))
         chunk[:, i1b - i1:i2b - i1] = self._recording.get_traces(start_frame=i1b, end_frame=i2b,
-                                                                 channel_ids=channel_ids)
+                                                                 channel_ids=channel_ids, return_scaled=return_scaled)
 
         return chunk
 

--- a/spiketoolkit/preprocessing/filterrecording.py
+++ b/spiketoolkit/preprocessing/filterrecording.py
@@ -46,7 +46,7 @@ class FilterRecording(BasePreprocessorRecordingExtractor):
             filtered_chunk = np.zeros((len(channel_ids), int(end_frame-start_frame)), dtype=dt)
             pos = 0
             for ich in range(ich1, ich2 + 1):
-                filtered_chunk0 = self._get_filtered_chunk(ich, channel_ids)
+                filtered_chunk0 = self._get_filtered_chunk(ich, channel_ids, return_scaled)
                 if ich == ich1:
                     start0 = start_frame - ich * self._chunk_size
                 else:
@@ -81,7 +81,7 @@ class FilterRecording(BasePreprocessorRecordingExtractor):
 
         return chunk
 
-    def _get_filtered_chunk(self, ind, channel_ids):
+    def _get_filtered_chunk(self, ind, channel_ids, return_scaled):
         if self._cache_chunks:
             code = str(ind)
             chunk0 = self._filtered_cache_chunks.get(code)
@@ -106,7 +106,8 @@ class FilterRecording(BasePreprocessorRecordingExtractor):
             chunk1 = chunk1[channel_idxs]
         else:
             # otherwise, only filter requested channels
-            chunk1 = self.filter_chunk(start_frame=start0, end_frame=end0, channel_ids=channel_ids)
+            chunk1 = self.filter_chunk(start_frame=start0, end_frame=end0, channel_ids=channel_ids,
+                                       return_scaled=return_scaled)
 
         return chunk1
             

--- a/spiketoolkit/preprocessing/highpass_filter.py
+++ b/spiketoolkit/preprocessing/highpass_filter.py
@@ -42,11 +42,11 @@ class HighpassFilterRecording(FilterRecording):
                         'freq_wid': freq_wid, 'filter_type': filter_type, 'order': order,
                         'chunk_size': chunk_size, 'cache_chunks': cache_chunks}
 
-    def filter_chunk(self, *, start_frame, end_frame, channel_ids):
+    def filter_chunk(self, *, start_frame, end_frame, channel_ids, return_scaled):
         padding = 3000
         i1 = start_frame - self._padding
         i2 = end_frame + self._padding
-        padded_chunk = self._read_chunk(i1, i2, channel_ids)
+        padded_chunk = self._read_chunk(i1, i2, channel_ids, return_scaled)
         filtered_padded_chunk = self._do_filter(padded_chunk)
         return filtered_padded_chunk[:, start_frame - i1:end_frame - i1]
 

--- a/spiketoolkit/preprocessing/mask.py
+++ b/spiketoolkit/preprocessing/mask.py
@@ -23,7 +23,7 @@ class MaskRecording(BasePreprocessorRecordingExtractor):
         traces = self._recording.get_traces(channel_ids=channel_ids,
                                             start_frame=start_frame,
                                             end_frame=end_frame,
-                                            return_scaled=True)
+                                            return_scaled=return_scaled)
 
         traces = traces.copy()  # takes care of memmap objects
         traces[:, ~self._mask[start_frame:end_frame]] = 0.0

--- a/spiketoolkit/preprocessing/normalize_by_quantile.py
+++ b/spiketoolkit/preprocessing/normalize_by_quantile.py
@@ -16,6 +16,7 @@ class NormalizeByQuantileRecording(BasePreprocessorRecordingExtractor):
 
         self._scalar = scale / pre_scale
         self._offset = median - pre_median * self._scalar
+        self.has_unscaled = False
         self._kwargs = {'recording': recording.make_serialized_dict(), 'scale': scale, 'median': median,
                         'q1': q1, 'q2': q2, 'seed': seed}
 
@@ -31,10 +32,12 @@ class NormalizeByQuantileRecording(BasePreprocessorRecordingExtractor):
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None, return_scaled=True):
+        assert return_scaled, "'normalize_by_quantile' only supports return_scaled=True"
+
         traces = self._recording.get_traces(channel_ids=channel_ids,
                                             start_frame=start_frame,
                                             end_frame=end_frame,
-                                            return_scaled=True)
+                                            return_scaled=return_scaled)
         return traces * self._scalar + self._offset
 
 

--- a/spiketoolkit/preprocessing/notch_filter.py
+++ b/spiketoolkit/preprocessing/notch_filter.py
@@ -19,11 +19,11 @@ class NotchFilterRecording(FilterRecording):
         self._kwargs = {'recording': recording.make_serialized_dict(), 'freq': freq,
                         'q': q, 'chunk_size': chunk_size, 'cache_chunks': cache_chunks}
 
-    def filter_chunk(self, *, start_frame, end_frame, channel_ids):
+    def filter_chunk(self, start_frame, end_frame, channel_ids, return_scaled):
         padding = 3000
         i1 = start_frame - padding
         i2 = end_frame + padding
-        padded_chunk = self._read_chunk(i1, i2, channel_ids)
+        padded_chunk = self._read_chunk(i1, i2, channel_ids, return_scaled)
         filtered_padded_chunk = self._do_filter(padded_chunk)
         return filtered_padded_chunk[:, start_frame - i1:end_frame - i1]
 

--- a/spiketoolkit/preprocessing/remove_artifacts.py
+++ b/spiketoolkit/preprocessing/remove_artifacts.py
@@ -21,7 +21,9 @@ class RemoveArtifactsRecording(BasePreprocessorRecordingExtractor):
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None, return_scaled=True):
-        traces = self._recording.get_traces(channel_ids=channel_ids, start_frame=start_frame, end_frame=end_frame,
+        traces = self._recording.get_traces(channel_ids=channel_ids,
+                                            start_frame=start_frame,
+                                            end_frame=end_frame,
                                             return_scaled=return_scaled)
         triggers = self._triggers[(self._triggers > start_frame) & (self._triggers < end_frame)] - start_frame
 
@@ -107,13 +109,13 @@ class RemoveArtifactsRecording(BasePreprocessorRecordingExtractor):
 
                 interp_traces = np.vstack((pre_vals, post_vals)).T
 
-                if (self._mode == 'cubic') & (len(all_idx) >= 5):
+                if self._mode == 'cubic' and len(all_idx) >= 5:
                     # Enough fit points present on either side to do cubic spline fit:
                     interp_function = interp1d(all_idx, interp_traces, self._mode,
                                                bounds_error=False,
                                                fill_value='extrapolate')
                     traces[:, gap_idx] = interp_function(gap_idx)
-                elif (self._mode == 'linear') & (len(all_idx) >= 2):
+                elif self._mode == 'linear' and len(all_idx) >= 2:
                     # Enough fit points present for a linear fit
                     interp_function = interp1d(all_idx, interp_traces, self._mode, bounds_error=False,
                                                fill_value='extrapolate')

--- a/spiketoolkit/preprocessing/resample.py
+++ b/spiketoolkit/preprocessing/resample.py
@@ -30,7 +30,7 @@ class ResampleRecording(BasePreprocessorRecordingExtractor):
         return int(self._recording.get_num_frames() / self._recording.get_sampling_frequency() * self._resample_rate)
 
     # avoid filtering one sample
-    def get_dtype(self):
+    def get_dtype(self, return_scaled=True):
         return self._dtype
 
     @check_get_traces_args

--- a/spiketoolkit/preprocessing/transform.py
+++ b/spiketoolkit/preprocessing/transform.py
@@ -17,12 +17,15 @@ class TransformRecording(BasePreprocessorRecordingExtractor):
         else:
             self._dtype = dtype
         BasePreprocessorRecordingExtractor.__init__(self, recording)
+        self.has_unscaled = False
 
         self._kwargs = {'recording': recording.make_serialized_dict(), 'scalar': scalar, 'offset': offset,
                         'dtype': dtype}
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None, return_scaled=True):
+        assert return_scaled, "'transform' only supports return_scaled=True"
+
         traces = self._recording.get_traces(channel_ids=channel_ids, start_frame=start_frame, end_frame=end_frame,
                                             return_scaled=return_scaled)
         if isinstance(self._scalar, (int, float, np.integer, np.float)):


### PR DESCRIPTION
- Some preprocessors compute parameters in the init (e.g. center, transform, etc.). These will not support `return_scaled=False`

- Propagated `return_scaled` to filter functions