### PR TITLE
Issue 390 local car implementation

### DIFF
--- a/spiketoolkit/preprocessing/common_reference.py
+++ b/spiketoolkit/preprocessing/common_reference.py
@@ -10,8 +10,7 @@ class CommonReferenceRecording(BasePreprocessorRecordingExtractor):
     preprocessor_name = 'CommonReference'
 
     def __init__(self, recording, reference='median', groups=None, ref_channels=None,
-                                  local_radius=(2,8),
-                                  dtype=None, verbose=False):
+                 local_radius=(2, 8), dtype=None, verbose=False):
 
         if not isinstance(recording, RecordingExtractor):
             raise ValueError("'recording' must be a RecordingExtractor")
@@ -65,7 +64,8 @@ class CommonReferenceRecording(BasePreprocessorRecordingExtractor):
                                                                                 start_frame=start_frame,
                                                                                 end_frame=end_frame,
                                                                                 return_scaled=return_scaled),
-                                                         axis=0, keepdims=True) for (split_channel, split_group) in zip(selected_channels, selected_groups)]))
+                                                     axis=0, keepdims=True) for (split_channel, split_group) in
+                                         zip(selected_channels, selected_groups)]))
         elif self._ref == 'average':
             if self.verbose:
                 if self._groups is None:
@@ -81,7 +81,8 @@ class CommonReferenceRecording(BasePreprocessorRecordingExtractor):
                                                                               start_frame=start_frame,
                                                                               end_frame=end_frame,
                                                                               return_scaled=return_scaled),
-                                                       axis=0, keepdims=True) for (split_channel, split_group) in zip(selected_channels, selected_groups)]))
+                                                   axis=0, keepdims=True) for (split_channel, split_group) in
+                                         zip(selected_channels, selected_groups)]))
         elif self._ref == 'single':
             if self.verbose:
                 if self._groups is None:
@@ -99,18 +100,19 @@ class CommonReferenceRecording(BasePreprocessorRecordingExtractor):
 
         elif self._ref == 'local':
             if self.verbose:
-               print('Local Common average using as reference channels in a ring-shape region with radius: '+ self._local_radius)
+                print(
+                    'Local Common average using as reference channels in a ring-shape region with radius: ' + self._local_radius)
 
             neighrest_id, distances = get_closest_channels(self._recording, channel_ids)
             traces = self._recording.get_traces(channel_ids=channel_ids, start_frame=start_frame,
                                                 end_frame=end_frame,
                                                 return_scaled=return_scaled) \
-                         - np.vstack(np.array([np.average(
-                                               self._recording.get_traces(
-                                                   channel_ids=neighrest_id[id, np.logical_and(self._local_radius[0] < distances[id],
-                                                                                                     distances[id] <= self._local_radius[1])],
-                                                   start_frame=start_frame, end_frame=end_frame, return_scaled=return_scaled), axis=0)
-                                     for id in range(len(channel_ids))]))
+                     - np.vstack(np.array([np.average(
+                self._recording.get_traces(
+                    channel_ids=neighrest_id[id, np.logical_and(self._local_radius[0] < distances[id],
+                                                                distances[id] <= self._local_radius[1])],
+                    start_frame=start_frame, end_frame=end_frame, return_scaled=return_scaled), axis=0)
+                for id in range(len(channel_ids))]))
 
         return np.array(traces).astype(self._dtype)
 
@@ -131,7 +133,8 @@ class CommonReferenceRecording(BasePreprocessorRecordingExtractor):
         return selected_groups, selected_channels
 
 
-def common_reference(recording, reference='median', groups=None, ref_channels=None, local_radius= (2,8), dtype=None, verbose=False):
+def common_reference(recording, reference='median', groups=None, ref_channels=None, local_radius=(2, 8), dtype=None,
+                     verbose=False):
     '''
     Re-references the recording extractor traces.
 
@@ -168,5 +171,6 @@ def common_reference(recording, reference='median', groups=None, ref_channels=No
         The re-referenced recording extractor object
     '''
     return CommonReferenceRecording(
-        recording=recording, reference=reference, groups=groups, ref_channels=ref_channels,  local_radius=local_radius, dtype=dtype, verbose=verbose
+        recording=recording, reference=reference, groups=groups, ref_channels=ref_channels, local_radius=local_radius,
+        dtype=dtype, verbose=verbose
     )

--- a/spiketoolkit/preprocessing/common_reference.py
+++ b/spiketoolkit/preprocessing/common_reference.py
@@ -128,7 +128,7 @@ class CommonReferenceRecording(BasePreprocessorRecordingExtractor):
                 return traces[channel_idxs].astype(self._dtype)
         elif self._ref == 'local':
             if self.verbose:
-                print('Local Common average using as channels in a ring-shape region with radius: '+ self._local_radius + 'around each electrods.')
+                print('Local Common average using as reference channels in a ring-shape region with radius: '+ self._local_radius)
             neighrest_id, distances = get_closest_channels(self._recording, channel_ids)
 
             traces = self._recording.get_traces(channel_ids=channel_ids, start_frame=start_frame,

--- a/spiketoolkit/tests/test_preprocessing.py
+++ b/spiketoolkit/tests/test_preprocessing.py
@@ -94,7 +94,7 @@ def test_common_reference():
     rec_cmr = common_reference(rec, reference='median')
     rec_car = common_reference(rec, reference='average')
     rec_sin = common_reference(rec, reference='single', ref_channels=0)
-    rec_local_car = common_reference(rec, reference='local', local_radius=1, num_local_channels=2)
+    rec_local_car = common_reference(rec, reference='local', local_radius=(1,3))
     rec_cmr_int16 = common_reference(rec, dtype='int16')
 
     traces = rec.get_traces()
@@ -103,10 +103,8 @@ def test_common_reference():
     assert not np.all(rec_sin.get_traces()[0])
     assert np.allclose(rec_sin.get_traces()[1], traces[1] - traces[0])
 
-    assert np.allclose(traces[2], rec_local_car.get_traces()[2] + np.mean(traces[[0]], axis=0, keepdims=True), atol=0.01)
     assert np.allclose(traces[0], rec_local_car.get_traces()[0] + np.mean(traces[[2,3]], axis=0, keepdims=True), atol=0.01)
     assert np.allclose(traces[1], rec_local_car.get_traces()[1] + np.mean(traces[[3]], axis=0, keepdims=True), atol=0.01)
-    assert np.allclose(traces[3], rec_local_car.get_traces()[3] + np.mean(traces[[0,1]], axis=0, keepdims=True), atol=0.01)
 
     assert 'int16' in str(rec_cmr_int16.get_dtype())
 
@@ -137,9 +135,9 @@ def test_common_reference():
 
     # Add test on a higher probes
     rec2, sort = se.example_datasets.toy_example(dump_folder='test', dumpable=True, duration=2, num_channels=8, seed=0)
-    rec_local_car2 = common_reference(rec2, reference='local', local_radius=2, num_local_channels=2)
+    rec_local_car2 = common_reference(rec2, reference='local', local_radius=(2,4))
     traces = rec2.get_traces()
-    assert np.allclose(traces[3], rec_local_car2.get_traces()[3] + np.mean(traces[[0, 6]], axis=0, keepdims=True), atol=0.01)
+    assert np.allclose(traces[3], rec_local_car2.get_traces()[3] + np.mean(traces[[0, 6,7]], axis=0, keepdims=True), atol=0.01)
 
     shutil.rmtree('test')
 

--- a/spiketoolkit/tests/test_preprocessing.py
+++ b/spiketoolkit/tests/test_preprocessing.py
@@ -133,6 +133,11 @@ def test_common_reference():
     check_dumping(rec_cmr_int16)
     check_dumping(rec_local_car)
 
+    # test with channels_ids
+    channels_ids = np.arange(0,2)
+    assert np.allclose(traces[channels_ids], rec_car.get_traces(channel_ids=channels_ids) + np.mean(traces, axis=0, keepdims=True), atol=0.01)
+    assert np.allclose(traces[channels_ids], rec_cmr_g.get_traces(channel_ids=channels_ids) + np.median(traces[[0, 1]], axis=0, keepdims=True), atol=0.01)
+
     # Add test on a higher probes
     rec2, sort = se.example_datasets.toy_example(dump_folder='test', dumpable=True, duration=2, num_channels=8, seed=0)
     rec_local_car2 = common_reference(rec2, reference='local', local_radius=(2,4))

--- a/spiketoolkit/tests/test_preprocessing.py
+++ b/spiketoolkit/tests/test_preprocessing.py
@@ -94,7 +94,7 @@ def test_common_reference():
     rec_cmr = common_reference(rec, reference='median')
     rec_car = common_reference(rec, reference='average')
     rec_sin = common_reference(rec, reference='single', ref_channels=0)
-    rec_local_car = common_reference(rec, reference='local', local_radius=(1,3))
+    rec_local_car = common_reference(rec, reference='local', local_radius=(1, 3))
     rec_cmr_int16 = common_reference(rec, dtype='int16')
 
     traces = rec.get_traces()
@@ -103,8 +103,10 @@ def test_common_reference():
     assert not np.all(rec_sin.get_traces()[0])
     assert np.allclose(rec_sin.get_traces()[1], traces[1] - traces[0])
 
-    assert np.allclose(traces[0], rec_local_car.get_traces()[0] + np.mean(traces[[2,3]], axis=0, keepdims=True), atol=0.01)
-    assert np.allclose(traces[1], rec_local_car.get_traces()[1] + np.mean(traces[[3]], axis=0, keepdims=True), atol=0.01)
+    assert np.allclose(traces[0], rec_local_car.get_traces()[0] + np.mean(traces[[2, 3]], axis=0, keepdims=True),
+                       atol=0.01)
+    assert np.allclose(traces[1], rec_local_car.get_traces()[1] + np.mean(traces[[3]], axis=0, keepdims=True),
+                       atol=0.01)
 
     assert 'int16' in str(rec_cmr_int16.get_dtype())
 
@@ -134,17 +136,22 @@ def test_common_reference():
     check_dumping(rec_local_car)
 
     # test with channels_ids
-    channels_ids = np.arange(0,2)
-    assert np.allclose(traces[channels_ids], rec_car.get_traces(channel_ids=channels_ids) + np.mean(traces, axis=0, keepdims=True), atol=0.01)
-    assert np.allclose(traces[channels_ids], rec_cmr_g.get_traces(channel_ids=channels_ids) + np.median(traces[[0, 1]], axis=0, keepdims=True), atol=0.01)
+    channels_ids = np.arange(0, 2)
+    assert np.allclose(traces[channels_ids],
+                       rec_car.get_traces(channel_ids=channels_ids) + np.mean(traces, axis=0, keepdims=True), atol=0.01)
+    assert np.allclose(traces[channels_ids],
+                       rec_cmr_g.get_traces(channel_ids=channels_ids) + np.median(traces[[0, 1]], axis=0,
+                                                                                  keepdims=True), atol=0.01)
 
     # Add test on a higher probes
     rec2, sort = se.example_datasets.toy_example(dump_folder='test', dumpable=True, duration=2, num_channels=8, seed=0)
-    rec_local_car2 = common_reference(rec2, reference='local', local_radius=(2,4))
+    rec_local_car2 = common_reference(rec2, reference='local', local_radius=(2, 4))
     traces = rec2.get_traces()
-    assert np.allclose(traces[3], rec_local_car2.get_traces()[3] + np.mean(traces[[0, 6,7]], axis=0, keepdims=True), atol=0.01)
+    assert np.allclose(traces[3], rec_local_car2.get_traces()[3] + np.mean(traces[[0, 6, 7]], axis=0, keepdims=True),
+                       atol=0.01)
 
     shutil.rmtree('test')
+
 
 @pytest.mark.implemented
 def test_mask():
@@ -190,6 +197,7 @@ def test_highpass_filter():
 
     check_dumping(rec_fft)
     shutil.rmtree('test')
+
 
 @pytest.mark.notimplemented
 def test_norm_by_quantile():

--- a/spiketoolkit/utils.py
+++ b/spiketoolkit/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def get_closest_channels(recording, channel_ids, num_channels=None):
     """Get closest channels + distances
 
@@ -23,7 +24,7 @@ def get_closest_channels(recording, channel_ids, num_channels=None):
     dist = []
 
     if num_channels:
-        num_channels = min(num_channels+1, len(recording.get_channel_locations()))
+        num_channels = min(num_channels + 1, len(recording.get_channel_locations()))
     else:
         num_channels = len(recording.get_channel_locations())
 
@@ -36,5 +37,4 @@ def get_closest_channels(recording, channel_ids, num_channels=None):
         closest_channels_id.append(np.argsort(distances)[1:num_channels])
         dist.append(np.sort(distances)[1:num_channels])
 
-
-    return np.array(closest_channels_id),np.array(dist)
+    return np.array(closest_channels_id), np.array(dist)

--- a/spiketoolkit/utils.py
+++ b/spiketoolkit/utils.py
@@ -1,9 +1,13 @@
 import numpy as np
 
-def get_closest_channels(recording, channel_ids, num_channels):
+def get_closest_channels(recording, channel_ids, num_channels=None):
     closest_channels_id = []
     dist = []
-    num_channels = min(num_channels, len(recording.get_channel_locations())-1)
+
+    if num_channels:
+        num_channels = min(num_channels+1, len(recording.get_channel_locations()))
+    else:
+        num_channels = len(recording.get_channel_locations())
 
     if not isinstance(channel_ids, list):
         channel_ids = list(channel_ids)
@@ -11,8 +15,8 @@ def get_closest_channels(recording, channel_ids, num_channels):
     for n, id in enumerate(channel_ids):
         locs = recording.get_channel_locations()
         distances = [np.linalg.norm(l - locs[id]) for l in locs]
-        closest_channels_id.append(np.argsort(distances)[1:num_channels+1])
-        dist.append(np.sort(distances)[1:num_channels+1])
+        closest_channels_id.append(np.argsort(distances)[1:num_channels])
+        dist.append(np.sort(distances)[1:num_channels])
 
 
     return np.array(closest_channels_id),np.array(dist)

--- a/spiketoolkit/utils.py
+++ b/spiketoolkit/utils.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+def get_closest_channels(recording, channel_ids, num_channels):
+    closest_channels_id = []
+    dist = []
+    num_channels = min(num_channels, len(recording.get_channel_locations())-1)
+
+    if not isinstance(channel_ids, list):
+        channel_ids = list(channel_ids)
+
+    for n, id in enumerate(channel_ids):
+        locs = recording.get_channel_locations()
+        distances = [np.linalg.norm(l - locs[id]) for l in locs]
+        closest_channels_id.append(np.argsort(distances)[1:num_channels+1])
+        dist.append(np.sort(distances)[1:num_channels+1])
+
+
+    return np.array(closest_channels_id),np.array(dist)

--- a/spiketoolkit/utils.py
+++ b/spiketoolkit/utils.py
@@ -1,6 +1,24 @@
 import numpy as np
 
 def get_closest_channels(recording, channel_ids, num_channels=None):
+    """Get closest channels + distances
+
+    Parameters
+    ----------
+    recording: RecordingExtractor
+        The recording extractor to be re-referenced
+    channel_ids: list or int
+        list of channels id to compute there near neighborhood
+    num_channels: int, optional
+        Maximum number of neighborhood channel to return
+
+    Returns
+    -------
+    : array (2d)
+        closest channel ids in ascending order for each channel id given in input
+    : array (2d)
+        distance in ascending order for each channel id given in input
+    """
     closest_channels_id = []
     dist = []
 


### PR DESCRIPTION
Remarks : 
- I did not implemented a group option as you (@alejoe91) said in the issue it should be something apply on all channels. Seems weird however - should I add one ? 
- I am still unsure that it is logical to have the local_radius option in common_reference as it is an option only for the local filtering. 

close   #390 

Description of the test case added : 
![image](https://user-images.githubusercontent.com/34722888/111609156-4f6b8980-87da-11eb-8990-bbc018acecb7.png)


Also, a little refactoring/clean-up of this code would be nice. I can do it in other PR if you want. 
For example, I would put this code in an external private method instead of being repeat  3 times. (Tell me if I am overstepping here :) )
```
  for g in self._groups:
                    new_chans = []
                    for chan in g:
                        if chan in self._recording.get_channel_ids():
                            new_chans.append(chan)
                    new_groups.append(new_chans)
```
Also, I am not an expert of pytest (I am more often using unittest). I notice if the test failed there is no clean up done. I am sure there is some way to specify a tear down method which is activated each time a test is finished whether or not it was a fail or a success.