### PR TITLE
Fix detectionfor multiple chunk and improve tests

### DIFF
--- a/spiketoolkit/sortingcomponents/detection.py
+++ b/spiketoolkit/sortingcomponents/detection.py
@@ -220,7 +220,7 @@ def _detect_and_align_peaks_chunk(ii, rec_arg, chunks, channel_ids, thresholds, 
 
     for ch in range(len(channel_ids)):
         peak_times = peak_sample_ind[np.where(peak_chan_ind == ch)]
-        sp_times.append(peak_sample_ind[np.where(peak_chan_ind == ch)])
+        sp_times.append(peak_sample_ind[np.where(peak_chan_ind == ch)] + chunk['istart'])
         sp_amplitudes.append(traces[ch, peak_times])
 
     return sp_times, sp_amplitudes

--- a/spiketoolkit/tests/test_sortingcomponents.py
+++ b/spiketoolkit/tests/test_sortingcomponents.py
@@ -3,51 +3,67 @@ import spiketoolkit as st
 import numpy as np
 import shutil
 
+
 def test_detection():
     folder = 'test'
     rec, sort = se.example_datasets.toy_example(num_channels=4, duration=20, seed=0, dumpable=True, dump_folder=folder)
 
     # negative
     sort_d_n = st.sortingcomponents.detect_spikes(rec)
-    sort_dp_n = st.sortingcomponents.detect_spikes(rec, n_jobs=2)
+    sort_dc_n = st.sortingcomponents.detect_spikes(rec, n_jobs=1, chunk_mb=10)
+    sort_dp_n = st.sortingcomponents.detect_spikes(rec, n_jobs=2, chunk_mb=10)
 
     assert 'channel' in sort_d_n.get_shared_unit_property_names()
+    assert 'channel' in sort_dc_n.get_shared_unit_property_names()
     assert 'channel' in sort_dp_n.get_shared_unit_property_names()
     assert 'spike_rate' in sort_d_n.get_shared_unit_property_names()
+    assert 'spike_rate' in sort_dc_n.get_shared_unit_property_names()
     assert 'spike_rate' in sort_dp_n.get_shared_unit_property_names()
     assert 'spike_amplitude' in sort_d_n.get_shared_unit_property_names()
+    assert 'spike_amplitude' in sort_dc_n.get_shared_unit_property_names()
     assert 'spike_amplitude' in sort_dp_n.get_shared_unit_property_names()
 
     for u in sort_d_n.get_unit_ids():
         assert np.array_equal(sort_d_n.get_unit_spike_train(u), sort_dp_n.get_unit_spike_train(u))
+        assert np.array_equal(sort_d_n.get_unit_spike_train(u), sort_dc_n.get_unit_spike_train(u))
 
     # positive
     sort_d_p = st.sortingcomponents.detect_spikes(rec, detect_sign=1)
-    sort_dp_p = st.sortingcomponents.detect_spikes(rec, detect_sign=1, n_jobs=2)
+    sort_dc_p = st.sortingcomponents.detect_spikes(rec, detect_sign=1, n_jobs=1, chunk_mb=10)
+    sort_dp_p = st.sortingcomponents.detect_spikes(rec, detect_sign=1, n_jobs=2, chunk_mb=10)
 
     assert 'channel' in sort_d_p.get_shared_unit_property_names()
+    assert 'channel' in sort_dc_p.get_shared_unit_property_names()
     assert 'channel' in sort_dp_p.get_shared_unit_property_names()
     assert 'spike_rate' in sort_d_p.get_shared_unit_property_names()
+    assert 'spike_rate' in sort_dc_p.get_shared_unit_property_names()
     assert 'spike_rate' in sort_dp_p.get_shared_unit_property_names()
     assert 'spike_amplitude' in sort_d_p.get_shared_unit_property_names()
+    assert 'spike_amplitude' in sort_dc_p.get_shared_unit_property_names()
     assert 'spike_amplitude' in sort_dp_p.get_shared_unit_property_names()
 
     for u in sort_d_p.get_unit_ids():
         assert np.array_equal(sort_d_p.get_unit_spike_train(u), sort_dp_p.get_unit_spike_train(u))
+        assert np.array_equal(sort_d_p.get_unit_spike_train(u), sort_dc_p.get_unit_spike_train(u))
 
     # both
     sort_d_b = st.sortingcomponents.detect_spikes(rec, detect_sign=0)
-    sort_dp_b = st.sortingcomponents.detect_spikes(rec, detect_sign=0, n_jobs=2)
+    sort_dc_b = st.sortingcomponents.detect_spikes(rec, detect_sign=0, n_jobs=2, chunk_mb=10)
+    sort_dp_b = st.sortingcomponents.detect_spikes(rec, detect_sign=0, n_jobs=2, chunk_mb=10)
 
     assert 'channel' in sort_d_b.get_shared_unit_property_names()
+    assert 'channel' in sort_dc_b.get_shared_unit_property_names()
     assert 'channel' in sort_dp_b.get_shared_unit_property_names()
     assert 'spike_rate' in sort_d_b.get_shared_unit_property_names()
+    assert 'spike_rate' in sort_dc_b.get_shared_unit_property_names()
     assert 'spike_rate' in sort_dp_b.get_shared_unit_property_names()
     assert 'spike_amplitude' in sort_d_b.get_shared_unit_property_names()
+    assert 'spike_amplitude' in sort_dc_b.get_shared_unit_property_names()
     assert 'spike_amplitude' in sort_dp_b.get_shared_unit_property_names()
 
     for u in sort_d_b.get_unit_ids():
         assert np.array_equal(sort_d_b.get_unit_spike_train(u), sort_dp_b.get_unit_spike_train(u))
+        assert np.array_equal(sort_d_b.get_unit_spike_train(u), sort_dc_b.get_unit_spike_train(u))
 
     shutil.rmtree(folder)
 


### PR DESCRIPTION
The tests were not running properly because `chunk_mb` was too large. The spikes detected in each chunk must be shifted by `chunk['istart']` 