### PR TITLE
Fix CMR when using groups and subselection of channels

### DIFF
--- a/spiketoolkit/preprocessing/common_reference.py
+++ b/spiketoolkit/preprocessing/common_reference.py
@@ -125,8 +125,10 @@ class CommonReferenceRecording(BasePreprocessorRecordingExtractor):
                 for chan in g:
                     if chan in self._recording.get_channel_ids():
                         new_chans.append(chan)
-                selected_groups.append(new_chans)
-                selected_channels.append([ch for ch in channel_ids if ch in new_chans])
+                selected_channel_for_group = [ch for ch in channel_ids if ch in new_chans]
+                if len(selected_channel_for_group) > 0:
+                    selected_groups.append(new_chans)
+                    selected_channels.append(selected_channel_for_group)
         else:
             selected_groups = [self._recording.get_channel_ids()]
             selected_channels = [channel_ids]


### PR DESCRIPTION
This fixes a bug occurring when multiple reference groups are used, but `get_traces` is called on a subset of channels that are only in a sub group