### PR TITLE
Fix/return scaled in get unit waveforms

### DIFF
--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1954,7 +1954,7 @@ def _template_descending_order(recording, templates, templates_ind):
 
 
 def _extract_waveforms_one_chunk(i, rec_arg, chunks, unit_ids, n_pad, times_in_chunk, cumulative_n_spikes,
-                                 waveforms_file, memmap, dtype, verbose):
+                                 waveforms_file, memmap, dtype, verbose, return_scaled=False):
     chunk = chunks[i]
     times_this_chunk = times_in_chunk[i]
     n_spikes = cumulative_n_spikes[i]
@@ -1979,7 +1979,8 @@ def _extract_waveforms_one_chunk(i, rec_arg, chunks, unit_ids, n_pad, times_in_c
         chunk=chunk,
         unit_ids=unit_ids,
         snippet_len=n_pad,
-        times_in_chunk=times_this_chunk
+        times_in_chunk=times_this_chunk,
+        return_scaled=return_scaled
     )
     t_stop = time.perf_counter()
     if verbose:

--- a/spiketoolkit/postprocessing/postprocessing_tools.py
+++ b/spiketoolkit/postprocessing/postprocessing_tools.py
@@ -1989,7 +1989,7 @@ def _template_descending_order(recording, templates, templates_ind):
 
 
 def _extract_waveforms_one_chunk(i, rec_arg, chunks, unit_ids, n_pad, times_in_chunk, cumulative_n_spikes,
-                                 waveforms_file, memmap, dtype, verbose, return_scaled=False):
+                                 waveforms_file, memmap, dtype, verbose, return_scaled=True):
     chunk = chunks[i]
     times_this_chunk = times_in_chunk[i]
     n_spikes = cumulative_n_spikes[i]

--- a/spiketoolkit/postprocessing/utils.py
+++ b/spiketoolkit/postprocessing/utils.py
@@ -151,7 +151,7 @@ def get_unit_waveforms_for_chunk(
         return_scaled=True
 ):
     # chunks are chosen small enough so that all traces can be loaded into memory
-    traces = recording.get_traces(return_scaled)
+    traces = recording.get_traces(return_scaled=return_scaled)
     frame_offset = chunk['istart'] - chunk['istart_with_padding']
 
     unit_waveforms = []

--- a/spiketoolkit/postprocessing/utils.py
+++ b/spiketoolkit/postprocessing/utils.py
@@ -148,9 +148,10 @@ def get_unit_waveforms_for_chunk(
         unit_ids,
         snippet_len,
         times_in_chunk,
+        return_scaled=True
 ):
     # chunks are chosen small enough so that all traces can be loaded into memory
-    traces = recording.get_traces()
+    traces = recording.get_traces(return_scaled)
     frame_offset = chunk['istart'] - chunk['istart_with_padding']
 
     unit_waveforms = []


### PR DESCRIPTION
I  noticed that while it is possible to specify `return_scaled=False` in `spiketoolkit.postprocessing.get_unit_waveforms()`, the data is actually read as float in `get_unit_waveforms_for_chunk()` as per the default in `get_traces()`: https://github.com/SpikeInterface/spiketoolkit/blob/877d70fe5395e37ea3f47683937eca6221e85cd1/spiketoolkit/postprocessing/utils.py#L153. It is then cast back to int8 (in my case) here: `_extract_waveforms_one_chunk()`https://github.com/SpikeInterface/spiketoolkit/blob/877d70fe5395e37ea3f47683937eca6221e85cd1/spiketoolkit/postprocessing/postprocessing_tools.py#L2026

To avoid this I have propagated the `return_scaled` parameter down to the children of `spiketoolkit.postprocessing.get_unit_waveforms()`. `pytest test_postprocessing` passed locally.
